### PR TITLE
Change instructions to build MLIR with check-all target instead of check-mlir

### DIFF
--- a/setup/macos.rst
+++ b/setup/macos.rst
@@ -340,7 +340,7 @@ Here are the steps to get MLIR up and running.
         -DLLVM_TARGETS_TO_BUILD="Native" \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_ENABLE_ASSERTIONS=ON
-    $ cmake --build . --target check-all
+    $ ninja check-all -j<number of threads>
 
 #. Add these configuration lines to your
    ``~/.zshenv``

--- a/setup/ubuntu.rst
+++ b/setup/ubuntu.rst
@@ -348,7 +348,7 @@ Here are the steps to get MLIR up and running.
         -DLLVM_TARGETS_TO_BUILD="Native" \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_ENABLE_ASSERTIONS=ON
-    $ cmake --build . --target check-all
+    $ ninja check-all -j<number of threads>
 
 #. Add these configuration lines to your
    ``~/.bashrc``


### PR DESCRIPTION
Students need `lli` to run the tester. `lli` is not built for the `check-mlir` target. So, I think we should build `check-all` instead of `check-mlir`.

Also, switch instructions to invoke `ninja` for the build command instead of `cmake --build` since I think it's more familiar.