### PR TITLE
Update setup for llvm 18 & simplify

### DIFF
--- a/setup/macos.rst
+++ b/setup/macos.rst
@@ -334,7 +334,7 @@ until you're about to start your assignment. Here are the steps to get MLIR up a
         -DLLVM_ENABLE_ASSERTIONS=ON
     $ ninja -j<number of threads>
 
-#. Add these configuration lines to your ``~/.zshrc`` file so that you can use
+#. Add these configuration lines to your ``~/.zshenv`` file so that you can use
    the MLIR tools and so that ``cmake`` will find your build.
 
    .. code-block:: shell

--- a/setup/ubuntu.rst
+++ b/setup/ubuntu.rst
@@ -321,7 +321,6 @@ until you're about to start your assignment. Here are the steps to get MLIR up a
 
    .. code-block:: console
 
-    $ git clone --depth 1 --branch llvmorg-18.1.8 https://github.com/llvm/llvm-project.git llvm-project-18.1.8
     $ git clone https://github.com/llvm/llvm-project.git
     $ cd llvm-project
     $ git checkout llvmorg-18.1.8


### PR DESCRIPTION
* Update install MLIR for LLVM `18.1.8`

* Small change: Instructions on how to build LLVM are agnostic to where llvm-project is cloned (previously had to be in $HOME)

* Remove the `setup-up your own project` section. I like the concept but in the interest of keeping 415 maintenance slim I think removing anything not absolutely necessary is worth it. IMO the base repositories are a sufficient setup test in themselves.