### PR TITLE
Changed maximum vector length to 2^31 -1

### DIFF
--- a/vcalc/impl/assertions.rst
+++ b/vcalc/impl/assertions.rst
@@ -21,10 +21,10 @@ specification particulars.
       **vector-length**:
 
    All vectors will have length :math:`l` such that
-   :math:`0 \leq l \leq 2^{32}`. Trying to create an index greater than
-   :math:`2^{32} - 1` will cause overflow and result in a negative
+   :math:`0 \leq l \leq 2^{31}-1`. Trying to create an index greater than
+   :math:`2^{31} - 1` will cause overflow and result in a negative
    number. Indexing with a negative number returns :math:`0`. Therefore,
-   vector locations greater than :math:`2^{32} - 1` would be
+   vector locations greater than :math:`2^{31} - 1` would be
    inaccessible. For example, the following tests would be considered
    invalid:
 
@@ -37,5 +37,5 @@ specification particulars.
 
    ::
 
-            print((0-2)..2147483645);
+            print((0-2)..2147483644);
 

--- a/vcalc/spec/vectors.rst
+++ b/vcalc/spec/vectors.rst
@@ -6,10 +6,10 @@ Vectors are restricted to the length that can be represented by the
 *largest possible index*. Indices are integers and integers are signed
 32 bit integers. Because the largest possible integer is
 :math:`2^{31} - 1` or :math:`2147483647`, a vector can have a length in
-the range :math:`[0, 2^{31}]`.
+the range :math:`[0, 2^{31}-1]`.
 
 **Assertion:** All vectors will have length :math:`l` such that
-:math:`0 \leq l \leq 2^{32}`. (:ref:`vector-length <assert:vector-length>`)
+:math:`0 \leq l \leq 2^{31}-1`. (:ref:`vector-length <assert:vector-length>`)
 
 There is no way to specify a vector literal, they must be created
 through ranges, generators, filters, or index expressions with a vector


### PR DESCRIPTION
The documentation was unclear on why 2^32 was the maximum length for vectors. It also caused confusion in the assignments.

This update reflects a better specification where the limits of the indices are the same as the limit to the size of the vector.