### PR TITLE
update: define n-d promotion rules for the initializing expression

### DIFF
--- a/gazprea/spec/type_promotion.rst
+++ b/gazprea/spec/type_promotion.rst
@@ -83,13 +83,7 @@ operand is a square matrix (:math:`m \times m`).
 Multi-dimensional Arrays
 --------------------------
 
-Array promotion to a higher dimension occurs because, for example,
-a row in a 2D array is equivalent to a 1D array.
-When a 2D array is initialized or operated on with a 1D array, each scalar
-element in the 1D array is interpreted as a row. By applying the scalar to
-array promotion rule, each scalar element in the array will be promoted
-to a row. The example below demonstrates scalar to row promotion,
-row padding and column padding all together.
+Array promotion to a higher dimension occurs when elements of the initialization array can be promoted from the corresponding element type of the declaration. For example, when a declaration of a 2D array (matrix) is initialized with a 1D array (vector), each scalar element in the 1D array is interpreted as a row. This is because higher dimensional arrays are defined as an array of arrays, therefore each scalar element is promoted to a 1D array. The example below demonstrates scalar to array promotion and dimension padding.
 
 ::
   
@@ -97,11 +91,7 @@ row padding and column padding all together.
     // m1 = [[1, 1, 1, 1], [1, 2, 3, 0], [0, 0, 0, 0]]
     
 
-The number of columns in each row are inferred, first by the expression
-indicating the column size in the type declaration, and second, if the columnn
-size is inferred as ``*``, by the size of the array literal or expression.
-Therefore, when the column size is infered, an array to matrix promotion always
-produces a square matrix.
+In the example above, the second size expression, representing the column length, is used for the implicit promotion from each RHS element. If the promotion size is infered using the ``*`` notation, a compile time ``SizeError`` should be thrown.
 
 ::
 

--- a/gazprea/spec/type_promotion.rst
+++ b/gazprea/spec/type_promotion.rst
@@ -78,31 +78,6 @@ requirements on the dimensionality of the the operands. The consequence is
 that scalars can only be promoted to a matrix if the matrix multiply
 operand is a square matrix (:math:`m \times m`).
 
-.. _ssec:typePromotion_atom:
-
-Multi-dimensional Arrays
---------------------------
-
-Array promotion to a higher dimension occurs when elements of the initialization array can be promoted from the corresponding element type of the declaration. For example, when a declaration of a 2D array (matrix) is initialized with a 1D array (vector), each scalar element in the 1D array is interpreted as a row. This is because higher dimensional arrays are defined as an array of arrays, therefore each scalar element is promoted to a 1D array. The example below demonstrates scalar to array promotion and dimension padding.
-
-::
-  
-    integer[3][4] m1 = [1,[1,2,3]];
-    // m1 = [[1, 1, 1, 1], [1, 2, 3, 0], [0, 0, 0, 0]]
-    
-
-In the example above, the second size expression, representing the column length, is used for the implicit promotion from each RHS element. If the promotion size is infered using the ``*`` notation, a compile time ``SizeError`` should be thrown.
-
-::
-
-    integer[2][*] m2 = [3, 4];
-    // m2 = [[3, 3], [4, 4]]
-
-Array promotions to a higher dimensionality apply in all contexts where
-operations on arrays are defined.
-
-.. _ssec:typePromotion_ttot:
-
 Tuple to Tuple
 --------------
 


### PR DESCRIPTION
I'm not super confident this behavior is well defined for arrays of arbitrary dimension. For 2D (matrices) and 1D (arrays, formerly vectors), I believe it is. The spec clearly tries to leave the door open for N-D in the future, but examples like this are unclear: 

```
integer[2][3][4] three = [[1,2],[3,4]];
```

The initialization expression is a literal 2D array. How should that promote into a 3D array? Extrapolating from the 1D -> 2D case, the resulting contents in `three` would be:

```
[
 [ [1, 2, 0],
   [3, 4, 0]],
 [ [1, 2, 0],
   [3, 4, 0]],
 [ [1, 2, 0],
   [3, 4, 0]],
 [ [1, 2, 0],
   [3, 4, 0]],
]
```

At the end of the day Gazprea still only supports 2D for now, so this doesn't really matter, just something to think about for the future.