### PR TITLE
make String usage more consistent

### DIFF
--- a/gazprea/spec/built_in_functions.rst
+++ b/gazprea/spec/built_in_functions.rst
@@ -63,7 +63,7 @@ The reverse built-in takes any array, and returns a reversed version of it.
 Format
 -------
 
-The ``format`` built-in takes any scalar as input and returns a string
+The ``format`` built-in takes any scalar as input and returns a String
 containing the formatted value of the scalar.
 
 ::
@@ -74,7 +74,7 @@ containing the formatted value of the scalar.
          "i = " || format(i) || ", r = " || format(r) || '\n' -> std_output;
          // Prints: "i = 24, r = 2.4\n"
 
-Note that ``format`` will have to allocate space to hold the return string.
+Note that ``format`` will have to allocate space to hold the return String.
 You will have to figure out how to manage the memory so it is reclaimed
 eventually.
 

--- a/gazprea/spec/functions.rst
+++ b/gazprea/spec/functions.rst
@@ -173,7 +173,7 @@ The arguments and return value of functions can have both explicit and inferred 
 
 ::
 
-         function to_real_vec(integer[\*] x) returns real[\*] {
+         function to_real_vec(integer[*] x) returns real[*] {
              /* Some code here */
          }
 
@@ -186,12 +186,12 @@ Like Rust, array *slices* may be passed as arguments:
 
 ::
 
-         function to_real_vec(integer[\*] x) returns real[\*] {
-            real[\*] rvec = x;
+         function to_real_vec(integer[*] x) returns real[*] {
+            real[*] rvec = x;
             return rvec;
          }
 
-         function slicer() returns real[\*] {
+         function slicer() returns real[*] {
              integer a[10] = 1..10;
              Vector<real> two_halves = to_real_vec(a[1..5]);
              two_halves.append(to_real_vec(a[6..]));

--- a/gazprea/spec/keywords.rst
+++ b/gazprea/spec/keywords.rst
@@ -66,7 +66,7 @@ not be used by a programmer.
 
 -  stream_state
 
--  string
+-  String
 
 -  true
 
@@ -75,6 +75,8 @@ not be used by a programmer.
 -  typedef
 
 -  var
+
+-  Vector
 
 -  while
 

--- a/gazprea/spec/type_promotion.rst
+++ b/gazprea/spec/type_promotion.rst
@@ -143,7 +143,9 @@ Field names of tuples are overwritten by the field names of the left-hand side i
      bar.c -> std_output; // 1
 
 
-If initializing a variable with a tuple via :ref:`sec:typeInference`, the variable is assumed to be the same type. Therefore, field names are also copied over accordingly. For example:
+If initializing a variable with a tuple via :ref:`sec:typeInference`, the
+variable is assumed to be the same type.
+Therefore, field names are also copied over accordingly. For example:
 
 ::
 
@@ -168,10 +170,10 @@ It is possible for a two sided promotion to occur with tuples. For example:
 Character Array to/from String
 -------------------------------
 
-A ``string`` can be implicitly converted to an array of ``character``\ s and vice-versa (two-way type promotion).
+A ``String`` can be implicitly converted to an array of ``character``\ s and vice-versa (two-way type promotion).
 
 ::
 
-     string str1 = "Hello"; /* str == "Hello" */
-     character[*] chars = str; /* chars == ['H', 'e', 'l', 'l', 'o'] */
-     string str2 = chars || [' ', 'W', 'o', 'r', 'l', 'd']; /* str2 == "Hello World" */
+     String str1 = "Hello"; /* str1 == "Hello" */
+     character[*] chars = str1; /* chars == ['H', 'e', 'l', 'l', 'o'] */
+     String str2 = chars || [' ', 'W', 'o', 'r', 'l', 'd']; /* str2 == "Hello World" */

--- a/gazprea/spec/typedef.rst
+++ b/gazprea/spec/typedef.rst
@@ -29,13 +29,14 @@ following is therefore legal:
     return i;
   }
 
-In addition to base types, ``typedef`` can be used with arrays,
-strings and tuples. Using ``typedef`` on tuples, or on arrays
-with sizes helps reusability and consistency:
+In addition to base types, ``typedef`` can be used with compound types (arrays,
+Vectors, and Strings) and aggregate types (structs and tuples).
+Using ``typedef`` on tuples, or on arrays with sizes helps reusability and
+consistency:
 
 ::
 
-  typedef tuple(string[64], integer, real) student_id_grade;
+  typedef tuple(character[64], integer, real) student_id_grade;
   student_id_grade chucky_cheese = ("C. Cheese", 123456, 77.0);
 
   typedef integer[2][3] two_by_three_matrix;

--- a/gazprea/spec/types/character.rst
+++ b/gazprea/spec/types/character.rst
@@ -73,7 +73,7 @@ The following operations are defined between ``character`` values.
 +------------+--------------------------+------------+---------------------------+-------------------+
 
 Scalar values with type ``character`` may be concatenated onto
-values with type ``string`` or arrays with type ``character``.
+variables with type ``String`` or arrays with type ``character``.
 
 Type Casting and Type Promotion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gazprea/spec/types/string.rst
+++ b/gazprea/spec/types/string.rst
@@ -3,13 +3,13 @@
 String
 ------
 
-A ``String`` is another object within *Gazprea*. Fundamentally, a ``String``
-is a ``Vector`` of ``character``. This means that, like a vector, a string
-behaves like a dynamically sized array, but because it is an object *Gazprea*
-can provide type specific features.
+A ``String`` is another object within *Gazprea*. Fundamentally, a ``String`` is
+a ``Vector`` of ``character``.
+This means that, like a Vector, a String behaves like a dynamically sized array,
+but because it is an object *Gazprea* can provide type specific features.
 
-``String`` vectors behave a lot like character arrays, but there are
-several differences between the two types:
+String vectors behave a lot like character arrays, but there are several
+differences between the two types:
 an :ref:`extra literal style <sssec:string_lit>`,
 the :ref:`result of a concatenation <sssec:string_ops>`
 and :ref:`behaviour when sent to an output stream <sssec:output_format>`.
@@ -19,8 +19,8 @@ and :ref:`behaviour when sent to an output stream <sssec:output_format>`.
 Declaration
 ~~~~~~~~~~~
 
-A string may be declared with the keyword ``String``. The same rules of
-:ref:`vector declarations <sssec:vec_decl>` also apply to strings, which means
+A String may be declared with the keyword ``String``. The same rules of
+:ref:`Vector declarations <sssec:vec_decl>` also apply to Strings, which means
 that all lenghts are inferred:
 
 ::
@@ -41,7 +41,7 @@ double quotes. For instance:
 
   String cats_meow = "The cat said \"Meow!\"\nThat was a good day.\n"
 
-Although strings and character arrays look similar, they are still treated
+Although Strings and character arrays look similar, they are still treated
 differently by the compiler:
 
 ::
@@ -65,14 +65,15 @@ prints:
 Operations
 ~~~~~~~~~~
 
-As character arrays, strings have all of the same operations defined on them as
-the other array data types, Remember that because a ``String`` and array of
-``character`` are fundamentally the same, the concatenation operation may be
-used to concatenate values of the two types.
-As well, a scalar ``character`` may be concatenated onto a ``String`` in the
-same way as it would be concatenated onto an array of ``character``.
-Note that because a ``String`` is a type of ``Vector``, concatenation may
-also be accomplished with ``concat`` and ``push`` methods:
+As character arrays, Strings have all of the same operations defined on them as
+the other array data types.
+Remember that because a ``String`` and array of ``character`` are fundamentally
+the same, the concatenation operation may be used to concatenate values of the
+two types.
+As well, a scalar character may be concatenated onto a String in the same way
+as it would be concatenated onto an array of characters.
+Note that because a ``String`` is a type of ``Vector``, concatenation may also
+be accomplished with ``concat`` and ``push`` methods:
 
 ::
 

--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -2,7 +2,7 @@ Vectors
 -------
 
 Vectors are language supported objects that allow for dynamically sized arrays.
-Once created, vectors in *Gazprea* behave exactly like arrays: they can be
+Once created, Vectors in *Gazprea* behave exactly like arrays: they can be
 intermixed with arrays in expressions; they can be use on the RHS of array
 declarations and initializations; and they can be passed as array arguments to
 subroutines and functions.
@@ -23,7 +23,7 @@ the literals ``<`` and ``>`` are used in the declaration)
             Vector<|type|> |identifier| = |type-array|;
 
 
-Unlike the array type, *Gazprea* vectors do not have an explicit size
+Unlike the array type, *Gazprea* Vectors do not have an explicit size
 specifier, often called *capacity* in other languages.
 
    ::
@@ -36,11 +36,11 @@ specifier, often called *capacity* in other languages.
 
 As a language supported object, *Gazprea* provides several methods for ``Vector``:
 
-- push() - pushes a new element to the back of the vector
+- push() - pushes a new element to the back of the Vector
 
-- len() - number of elements in the vector
+- len() - number of elements in the Vector
 
-- append - append another array slice to the vector
+- append - append another array slice to the Vector
   
    ::
 
@@ -52,15 +52,15 @@ As a language supported object, *Gazprea* provides several methods for ``Vector`
 Operations
 ~~~~~~~~~~~
 
-Operations on ``Vectors`` are identical syntactically and semantically to
+Operations on Vectors are identical syntactically and semantically to
 operations on arrays. In particular, operand lengths must match for binary
 expressions and dot product.
 
-A ``Vector`` or vector slice can be passed as a call argument that has been
+A Vector or Vector slice can be passed as a call argument that has been
 declared as an array slice of the same size and type.
 
-When indexing a vector of arrays, the first index selects the array element
-within the vector, and the second index selects the element within the array:
+When indexing a Vector of arrays, the first index selects the array element
+within the Vector, and the second index selects the element within the array:
 
  ::
 


### PR DESCRIPTION
I try to use String whenever referring to the Gazprea object, and ``string`` no longer exists as a keyword.

I removed the \tt font in most cases, even though this is probably not grammatically correct.

Fixes #53 