### PR TITLE
update: late policy for f25

### DIFF
--- a/base/index.html
+++ b/base/index.html
@@ -59,11 +59,11 @@
             <a href="setup/" target="_blank">setup</a>
             <a href="https://cmput415.github.io/415-lectures/" target="_blank">2020 lectures</a>
             <a href="https://www.cmput415compilerexplorer.com/" target="_blank">godbolt</a>
-            <a href="info/" target="_blank">more info</a>
+            <a href="info/" target="_blank">grading &amp tips</a>
         </nav> 
     </main>
     <footer>
-        <div>&copy; 2024 University of Alberta</div>
+        <div>&copy; 2025 University of Alberta</div>
     </footer>
     <script src="css/main.js"></script>
 </body>

--- a/info/grading.rst
+++ b/info/grading.rst
@@ -29,6 +29,15 @@ The following table shows the weight distribution for each grading category acro
 | Performance Testing    | 0%        | 0%      | 0%      | 0%           | 10%          |
 +------------------------+-----------+---------+---------+--------------+--------------+
 
+Late Policy
+---------------------------------------------------
+At the moment of the deadline repositories are automatically pulled from Github Classroom. In the case
+of a late submission, the following policy is employed.
+
+* Late submissions within the first 24 hour interval after the deadline are excluded from the competitive testing tournament.
+* If competitive testing is not being organized for this assignment for any reason, a commensurate deduction will be applied.
+* Each 24 hour interval thereafter a 10% deduction is incurred.
+* Marks for submissions late beyond three days are capped at the minimum passing grade. 
 
 Code Style and Consistency
 ---------------------------------------------------


### PR DESCRIPTION
Prototype of late policy.

Excluding a late assignment from competitive testing already incurs a 20% deduction, so this policy only applies additional deductions from the second late-day on. 

It essentially goes:

(0,24 hrs] late:  - %20  
(24,48 hrs] late:  - %30
(48,72 hrs] late:  - %40

Beyond that it is pass/fail according to course administrators. Let me know what you guys think.