### PR TITLE
setup: Modify CMAKE instructions for ANTLR

### DIFF
--- a/setup/ubuntu.rst
+++ b/setup/ubuntu.rst
@@ -98,13 +98,14 @@ you can modify these steps appropriately.
    This should create a new folder called ``antlr4`` in ``ANTLR_PARENT``. We'll
    refer to this new directory (``<ANTLR_PARENT>/antlr4``) as ``SRC_DIR``.
 
-#. We will be using ANTLR 4.13.0 so we need to change to the git tag for version
-   4.13.0.
+#. We will be using ANTLR 4.13.2 so we need to change to the git tag for version
+   4.13.2. **NOTE** If you are using ``cmake`` version 4 or higher, you may need
+   to use the `dev` branch.
 
    .. code-block:: console
 
     $ cd <SRC_DIR>
-    $ git checkout 4.13.0
+    $ git checkout dev
 
    This will give you a warning about being in a “detached head state”. Since we
    won't be changing anything in ANTLR there is no need to create a branch. No
@@ -152,17 +153,13 @@ you can modify these steps appropriately.
    .. code-block:: console
 
     $ cd <BUILD_DIR>
-    $ cmake <SRC_DIR>/runtime/Cpp/ \
+    $ cmake -G Ninja -S <SRC_DIR>/runtime/Cpp/ \
         -DCMAKE_BUILD_TYPE=RELEASE \
-        -DLLVM_ENABLE_RTTI=ON \  # for using llvm::cl (see below)
         -DCMAKE_INSTALL_PREFIX="<INSTALL_DIR>"
 
    You will be presented with some CMake warnings but they're safe to ignore.
 
-   The `llvm::cl` system requires the runtime type information to be enabled,
-   which provides some runtime reflection capabilities to the system.
-
-#. We can finally run ``make`` to build the library and install it. You can make
+#. We can finally run ``ninja`` to build the library and install it. You can make
    the process significantly faster by running with multiple threads using the
    ``-j`` option and specifying a thread count. Using the option without a count
    will use unlimited threads. Be careful when using unlimited threads, the
@@ -172,7 +169,7 @@ you can modify these steps appropriately.
 
    .. code-block:: console
 
-    $ make install -j<number of threads>
+    $ ninja install -j<number of threads>
 
 #. Now we can add the install to your bash environment.
    Pick your favorite text editor, open ``~/.bashrc``,


### PR DESCRIPTION
CMake fails due to googletest requiring cmake 3.5 compatibility which is removed with cmake v4.

This tells students to use either 4.13.2 (for cmake 3... until 4) or the `dev` branch if they are using cmake 4+