### PR TITLE
[CHANGE] Type namespace != Function/Procedure/Variable namespace

### DIFF
--- a/gazprea/index.rst
+++ b/gazprea/index.rst
@@ -18,6 +18,7 @@ Hardware Acceleration Laboratory in Markham, ON.
 
    spec/keywords
    spec/identifiers
+   spec/namespaces
    spec/comments
    spec/declarations
    spec/type_qualifiers

--- a/gazprea/spec/functions.rst
+++ b/gazprea/spec/functions.rst
@@ -211,10 +211,6 @@ In *Gazprea* function declarations occur in the global scope.
 This means that two functions with the same name cannot coexist in the same
 gazprea program, nor can you forward declare the same function twice.
 
-Additionally, functions share the following namespaces:
-
--  The ``struct`` namespace: you cannot have a struct and function with the same
-   name in the same gazprea program.
-
--  The ``procedure`` namespace: You cannot have a procedure and function with
-   the same name in the same gazprea program.
+Functions and procedures share one namespace, so you cannot declare a function
+and a procedure with the same name. Functions do not conflict with user-defined
+types. See :ref:`sec:namespaces`.

--- a/gazprea/spec/identifiers.rst
+++ b/gazprea/spec/identifiers.rst
@@ -31,33 +31,5 @@ a number, contain invalid characters, or are a keyword:
 
 *Gazprea* imposes no restrictions on the length of identifiers.
 
-.. _ssec:namespace:
-
-Namespaces
-==========
-
-Identifiers are used by variables, user-defined types, functions and procedures.
-
-For the most part, user-defined types are in their own namespace because their
-usage does not collide with variables or functions.
-The one exception is that struct literals can look like function calls:
-
-::
-
-   struct A (integer i, real j);
-   A a = A(i, j);
-
-Consequently, struct literals and functions share the same namespace.
-In the above example, a definition of function ``A`` should generate a
-``SymbolError``, but a definition of variable ``A`` would not.
-Outside of types, variables and functions/procedures share the same namespace
-in a scope and shadowing is possible between these types.
-
-::
-
-   function x() returns integer; // "x" refers to this function in the global scope
-
-   procedure main() {
-     integer x = 3; // "x" refers to this variable in the scope of main
-   }
-   ...
+The rules governing which identifiers may coexist are described in
+:ref:`sec:namespaces`.

--- a/gazprea/spec/namespaces.rst
+++ b/gazprea/spec/namespaces.rst
@@ -1,0 +1,44 @@
+.. _sec:namespaces:
+
+Namespaces
+==========
+
+There are two namespaces in *Gazprea*:
+
+- Type namespace: user-defined types (structs and typealiases).
+- Variable/function/procedure namespace: variables, functions, and procedures.
+
+Items in separate namespaces may share an identifier. Items within the same
+namespace cannot share an identifier; this is a ``SymbolError``.
+
+::
+
+    // Does not conflict with the other statements
+    struct x (integer a, integer b);
+
+    // These three statements all conflict with each other.
+    // Any two of them in the same program produces a SymbolError.
+    integer x = 3;
+    function x() returns integer;
+    procedure x() returns integer;
+
+::
+
+    // Type names and value names live in separate namespaces, so the
+    // following identifiers do not collide.
+
+    typealias integer a;
+    typealias integer main; // Procedure and type do not conflict
+    struct b (a b, a a, main main); // Struct field names do not conflict with anything
+
+    procedure main() returns integer {
+
+        a a = 1; // type and variable do not conflict
+
+        b b = b(a, 2, 3);
+
+        if (true) { // New scope
+            a a = b.b; // New `a` shadows the old `a`
+        }
+        return 0;
+    }

--- a/gazprea/spec/procedures.rst
+++ b/gazprea/spec/procedures.rst
@@ -237,19 +237,15 @@ value of procedures can have both explicit and inferred sizes.
 Similarly, slices can be used whereever arrays are declared as parameters, and
 unlike functions, array parameters in procedures can be ``var``.
 
-.. _ssec:function_namespacing:
+.. _ssec:procedure_namespacing:
 
 Procedure Namespacing
---------------------
+---------------------
 
 In *Gazprea* procedure declarations occur in the global scope.
 This means that two procedures with the same name cannot coexist in the same
 gazprea program, nor can you forward declare the same procedure twice.
 
-Additionally, procedures share the following namespaces:
-
--  The ``struct`` namespace: you cannot have a struct and function with the same
-   name in the same gazprea program.
-
--  The ``function`` namespace: You cannot have a procedure and function with
-   the same name in the same gazprea program.
+Procedures and functions share one namespace, so you cannot declare a procedure
+and a function with the same name. Procedures do not conflict with user-defined
+types. See :ref:`sec:namespaces`.

--- a/gazprea/spec/types/struct.rst
+++ b/gazprea/spec/types/struct.rst
@@ -139,19 +139,14 @@ A struct itself cannot be cast or promoted. However, the fields within a struct
 can be individually cast/promoted, as described in
 sections :ref:`sec:typeCasting` and :ref:`sec:typePromotion`.
 
-.. _ssec:function_namespacing:
+.. _ssec:struct_namespacing:
 
 Struct Namespacing
---------------------
+------------------
 
 In *Gazprea*, struct declarations can occur in *any* scope.
 This means that two struct types with the same name *can* coexist in the same
-gazprea program so long as they are not in the same scope
+gazprea program so long as they are not in the same scope.
 
-Additionally, ``structs`` share the following namespaces:
-
--  The ``procedure`` namespace: You cannot have a procedure and struct with
-   the same name in the same gazprea program.
-
--  The ``function`` namespace: You cannot have a function and struct with
-   the same name in the same gazprea program.
+Structs live in the type namespace and therefore never conflict with variables,
+functions, or procedures. See :ref:`sec:namespaces`.


### PR DESCRIPTION
This is a suggestion also pulled from my other PR just to clarify the naming rules on structs. I propose that type names live in a different namespace to the rest of the named statements in gazprea.

That means that things like

```gaz
typealias main = integer;
struct foo (main a, main b);

procedure main() returns integer { ... }
function foo() returns foo { ... }
```

would be legal. This deviates from what we did last year with structs sharing the function namespace due to declaration syntax. To that effect, I propose that we change struct declaration syntax but that can live in another PR, or if this seems like a sensible idea I could merge it into this one.