### PR TITLE
[FIX]: Gazprea vars are implicitly const

### DIFF
--- a/gazprea/spec/built_in_functions.rst
+++ b/gazprea/spec/built_in_functions.rst
@@ -111,8 +111,8 @@ read has been issued.
 
 ::
 
-    boolean b;
-    integer i;
+    var boolean b;
+    var integer i;
 
     // Input stream: 9
     b <- std_input;              // b = false (error reading boolean)

--- a/gazprea/spec/procedures.rst
+++ b/gazprea/spec/procedures.rst
@@ -69,9 +69,9 @@ These procedures can be called as follows:
 
 ::
 
-         integer x = 12;
-         integer y = 21;
-         integer[5] v = 13;
+         var integer x = 12;
+         var integer y = 21;
+         var integer[5] v = 13;
 
          call change_first(v); /* v == [7, 13, 13, 13, 13] */
          call increment(x); /* x == 13 */

--- a/gazprea/spec/statements.rst
+++ b/gazprea/spec/statements.rst
@@ -496,5 +496,5 @@ Input example:
 
 ::
 
-         integer x;
+         var integer x;
          x <- std_input; /* Read an integer into x */

--- a/gazprea/spec/types/struct.rst
+++ b/gazprea/spec/types/struct.rst
@@ -64,7 +64,8 @@ Access
 For example:
 ::
 
-     struct s1 (integer i, real r, integer[10] iv) t1;
+     struct s1 (integer i, real r, integer[10] iv);
+     var s1 t1;
      t1.i
      t1.iv[2]
      t1.r

--- a/gazprea/spec/types/tuple.rst
+++ b/gazprea/spec/types/tuple.rst
@@ -12,11 +12,13 @@ Declaration
 
 A tuple value is declared with the keyword ``tuple`` followed by a
 parentheses-surrounded, comma-separated list of types. The list must
-contain *at least two elements*. Tuples are *mutable*. For example:
+contain *at least two elements*. As with any other type, a tuple variable
+is mutable only when declared ``var`` (see :ref:`sec:typeQualifiers`).
+For example:
 
 ::
 
-     tuple(integer, real, integer[10]) t1;
+     var tuple(integer, real, integer[10]) t1;
      tuple(character, real, character[256], real) t2;
 
 Note that while each tuple declaration defines a new type, the tuple type


### PR DESCRIPTION
Some examples surfaced with implicitly var definitions. Ideally I think we would automatically tangle all of the spec code into tests and then run them all via ci, but I think that will take some effort, so I defer.

For now, this is my constants fix.