### PR TITLE
[FIX]: Gazprea iterators are non-mutable within their nested scope

### DIFF
--- a/gazprea/spec/expressions.rst
+++ b/gazprea/spec/expressions.rst
@@ -144,8 +144,11 @@ instance:
 
 This is true for domain expressions within generators as well.
 
-Iterator variables can be assigned to and re-declared within the enclosed iterator loop.
-The variable is re-initialized according to the expression each iteration.
+An iterator variable is a fresh *constant* binding in each iteration:
+assigning to it is an error, but a declaration inside the loop body may
+shadow it, exactly as in any other nested scope. The shadowing declaration
+does not affect the iteration; the iterator is re-bound from the domain at
+the start of each iteration.
 
 ::
 

--- a/gazprea/spec/statements.rst
+++ b/gazprea/spec/statements.rst
@@ -359,8 +359,10 @@ Array ranges can also be used instead:
              i -> std_output;
            }
 
-The domain is evaluated once during the first iteration of the loop. Each iteration
-defines a constant domain variable from it's respective index. For instance:
+The domain is evaluated once during the first iteration of the loop. Each
+iteration defines a constant domain variable from its respective index;
+the variable cannot be assigned to, though it may be shadowed by an inner
+declaration (see :ref:`ssec:expressions_dom_expr`). For instance:
 
 ::
 


### PR DESCRIPTION
This is my interpretation of the spec, that for iterator values, it is invalid to assign to them in the iterator body,  but that variables can shadow the inner definition. Is that correct?

The second fix is for loop iterators. I have this implemented such that if you shadow the iterator, you effectively hide the iterator variable (as per usual with nested scopes) and then at the start of the next loop before redefinition the iterator variable takes on the iterator value.