### PR TITLE
[stack 10/20] spec(gazprea): name error classes at anonymous error sites

### DIFF
--- a/gazprea/spec/built_in_functions.rst
+++ b/gazprea/spec/built_in_functions.rst
@@ -12,7 +12,7 @@ The name of built in functions are reserved and a user program cannot
 define a function or a procedure with the same name as a built-in function.
 If a :term:`declaration` or a :term:`definition` with the same name as a
 built-in function is encountered in a *Gazprea* program, then the compiler
-must issue a ``SymbolError`` (see :ref:`sec:errors`).
+must emit a ``SymbolError`` (see :ref:`sec:errors`).
 
 Note that although the examples below all use arrays, all the built-ins work
 on Vectors and Strings, since they are always compatible with arrays.

--- a/gazprea/spec/built_in_functions.rst
+++ b/gazprea/spec/built_in_functions.rst
@@ -12,7 +12,7 @@ The name of built in functions are reserved and a user program cannot
 define a function or a procedure with the same name as a built-in function.
 If a :term:`declaration` or a :term:`definition` with the same name as a
 built-in function is encountered in a *Gazprea* program, then the compiler
-should issue an error.
+must issue a ``SymbolError`` (see :ref:`sec:errors`).
 
 Note that although the examples below all use arrays, all the built-ins work
 on Vectors and Strings, since they are always compatible with arrays.

--- a/gazprea/spec/declarations.rst
+++ b/gazprea/spec/declarations.rst
@@ -50,9 +50,9 @@ the beginning of a block. For instance this would not be legal in
        }
 
 because the declaration of the real version of ``i`` does not occur at
-the start of the block. A declaration that appears after the leading
-declaration block of an enclosing block statement must emit a
-``StatementError``.
+the start of the block. The compiler must emit a ``StatementError`` for
+any declaration that appears after the declaration prefix at the start of
+its enclosing block statement.
 
 The following declaration placement is legal:
 

--- a/gazprea/spec/declarations.rst
+++ b/gazprea/spec/declarations.rst
@@ -50,7 +50,9 @@ the beginning of a block. For instance this would not be legal in
        }
 
 because the declaration of the real version of ``i`` does not occur at
-the start of the block.
+the start of the block. A declaration that appears after the leading
+declaration block of an enclosing block statement must emit a
+``StatementError``.
 
 The following declaration placement is legal:
 
@@ -72,11 +74,10 @@ therefore :term:`ill-formed`.
        integer i = i;
        integer[10] v = v[0] * 2;
 
-A ``SymbolError`` (see :ref:`sec:errors`) must be raised about the use of
-undeclared variables
-in these cases. If a variable of the same name is declared in an
-enclosing :term:`scope`, then it is legal to use that in the initialization
-of a variable with the same name. For instance:
+The compiler must emit a ``SymbolError`` (see :ref:`sec:errors`) for the
+use of undeclared variables in these cases. If a variable of the same name
+is declared in an enclosing :term:`scope`, then it is legal to use that in
+the initialization of a variable with the same name. For instance:
 
 ::
 

--- a/gazprea/spec/declarations.rst
+++ b/gazprea/spec/declarations.rst
@@ -72,7 +72,8 @@ therefore :term:`ill-formed`.
        integer i = i;
        integer[10] v = v[0] * 2;
 
-An error message should be raised about the use of undeclared variables
+A ``SymbolError`` (see :ref:`sec:errors`) must be raised about the use of
+undeclared variables
 in these cases. If a variable of the same name is declared in an
 enclosing :term:`scope`, then it is legal to use that in the initialization
 of a variable with the same name. For instance:

--- a/gazprea/spec/expressions.rst
+++ b/gazprea/spec/expressions.rst
@@ -55,7 +55,8 @@ A generator may be used to construct either a one or two dimensional array.
 A generator creates a value of a 1D array type when one
 :term:`iterator variable` is used, and a 2D array type when two
 iterator variables are used.
-Any other number of iterator variables will yield an error.
+Any other number of iterator variables will yield a ``SyntaxError``
+(see :ref:`sec:errors`).
 In particular, *Gazprea* does not currently support generators over
 three or more iterator variables (no direct construction of arrays
 with three or more dimensions).

--- a/gazprea/spec/expressions.rst
+++ b/gazprea/spec/expressions.rst
@@ -55,7 +55,7 @@ A generator may be used to construct either a one or two dimensional array.
 A generator creates a value of a 1D array type when one
 :term:`iterator variable` is used, and a 2D array type when two
 iterator variables are used.
-Any other number of iterator variables will yield a ``SyntaxError``
+Any other number of iterator variables must emit a ``SyntaxError``
 (see :ref:`sec:errors`).
 In particular, *Gazprea* does not currently support generators over
 three or more iterator variables (no direct construction of arrays

--- a/gazprea/spec/functions.rst
+++ b/gazprea/spec/functions.rst
@@ -7,7 +7,7 @@ A function in *Gazprea* has several requirements:
 
 1.  All of the arguments are implicitly ``const``, and can not be mutable.
 
-2.  Function arguments cannot contain type qualifiers. Including a type qualifier with a function argument should result in a ``SyntaxError``.
+2.  Function arguments cannot contain type qualifiers. Including a type qualifier with a function argument must emit a ``SyntaxError`` (see :ref:`sec:errors`).
 
 3.  Argument types must be explicit. Inferred size arrays are allowed
 
@@ -80,7 +80,10 @@ A function’s body can also be given by a block statement instead of a
 single expression. In this case the return value of the function is
 given with the return statement. A return statement must be reached by
 all possible control flows in the function before the end of the
-function is encountered.
+function is encountered; if this cannot be established the compiler must
+emit a ``ReturnError``. Control-flow constructs are assumed to be
+undecidable, so both branches of every conditional are considered
+reachable.
 
 ::
 

--- a/gazprea/spec/functions.rst
+++ b/gazprea/spec/functions.rst
@@ -81,9 +81,7 @@ single expression. In this case the return value of the function is
 given with the return statement. A return statement must be reached by
 all possible control flows in the function before the end of the
 function is encountered; if this cannot be established the compiler must
-emit a ``ReturnError``. Control-flow constructs are assumed to be
-undecidable, so both branches of every conditional are considered
-reachable.
+emit a ``ReturnError`` (see :ref:`sec:errors`).
 
 ::
 

--- a/gazprea/spec/globals.rst
+++ b/gazprea/spec/globals.rst
@@ -20,10 +20,10 @@ Variable Declarations
 
 In *Gazprea* values can be assigned to a global :term:`identifier`. All
 globals must be immutable (``const``). If a global identifier is declared
-with the ``var`` specifier, then a ``GlobalError`` (see :ref:`sec:errors`)
-must be raised. This restriction is in place since mutable global variables
-would ruin :term:`functional purity`. If functions have access to mutable
-global state then we can not guarantee their purity.
+with the ``var`` specifier, then the compiler must emit a ``GlobalError``
+(see :ref:`sec:errors`). This restriction is in place since mutable global
+variables would ruin :term:`functional purity`. If functions have access to
+mutable global state then we can not guarantee their purity.
 
 Globals must be initialized with a valid
 :ref:`constant expression <sec:constexpr>`. A global :term:`initializer`
@@ -40,5 +40,10 @@ program runs. This preserves functional purity and enables
     permitted: ``[*]`` denotes an inferred size that is fixed by its
     ``constexpr`` initializer at compile time.
 *   All globals are implicitly ``constexpr``.
+
+The compiler must emit a ``GlobalError`` if any of these restrictions are
+violated, including a global that is not initialized, a global with an
+initializer that is not a valid constant expression, and a global whose
+type is ``vector``.
 
 

--- a/gazprea/spec/globals.rst
+++ b/gazprea/spec/globals.rst
@@ -41,9 +41,7 @@ program runs. This preserves functional purity and enables
     ``constexpr`` initializer at compile time.
 *   All globals are implicitly ``constexpr``.
 
-The compiler must emit a ``GlobalError`` if any of these restrictions are
-violated, including a global that is not initialized, a global with an
-initializer that is not a valid constant expression, and a global whose
-type is ``vector``.
+Violations of any of the above must be reported as a ``GlobalError``
+(see :ref:`sec:errors`).
 
 

--- a/gazprea/spec/globals.rst
+++ b/gazprea/spec/globals.rst
@@ -20,10 +20,10 @@ Variable Declarations
 
 In *Gazprea* values can be assigned to a global :term:`identifier`. All
 globals must be immutable (``const``). If a global identifier is declared
-with the ``var`` specifier, then an error should be raised. This restriction
-is in place since mutable global variables would ruin
-:term:`functional purity`. If functions have access to mutable global
-state then we can not guarantee their purity.
+with the ``var`` specifier, then a ``GlobalError`` (see :ref:`sec:errors`)
+must be raised. This restriction is in place since mutable global variables
+would ruin :term:`functional purity`. If functions have access to mutable
+global state then we can not guarantee their purity.
 
 Globals must be initialized with a valid
 :ref:`constant expression <sec:constexpr>`. A global :term:`initializer`

--- a/gazprea/spec/procedures.rst
+++ b/gazprea/spec/procedures.rst
@@ -80,7 +80,7 @@ These procedures can be called as follows:
 Only procedures may be called with ``call``. Functions must
 appear in expressions because they can not cause side effects, so using
 a function in a ``call`` statement would not do anything. *Gazprea*
-must raise a ``CallError`` (see :ref:`sec:errors`) if a function is used in
+must emit a ``CallError`` (see :ref:`sec:errors`) if a function is used in
 a ``call`` statement.
 
 A procedure may never be called within a function, doing so would allow for
@@ -103,7 +103,7 @@ These restrictions are made by *Gazprea* in order to allow for more
 optimizations.
 
 Procedures without a return clause may not be used in an expression.
-*Gazprea* must raise a ``CallError`` in such a case.
+*Gazprea* must emit a ``CallError`` in such a case.
 ::
 
          /* p is some procedure with no return clause */
@@ -177,8 +177,8 @@ In *Gazprea* a program that aliases mutable variables is
 :term:`ill-formed`.  The only case
 where aliasing of arguments is allowed is through disjoint tuple or struct field access. This
 helps *Gazprea* compilers perform more optimizations. However, the compiler must be able
-to catch cases where mutable memory locations are aliased, and an
-``AliasingError`` must be raised when this is detected. For instance:
+to catch cases where mutable memory locations are aliased, and must emit
+an ``AliasingError`` when this is detected. For instance:
 
 ::
 

--- a/gazprea/spec/procedures.rst
+++ b/gazprea/spec/procedures.rst
@@ -80,8 +80,8 @@ These procedures can be called as follows:
 Only procedures may be called with ``call``. Functions must
 appear in expressions because they can not cause side effects, so using
 a function in a ``call`` statement would not do anything. *Gazprea*
-must emit a ``CallError`` (see :ref:`sec:errors`) if a function is used in
-a ``call`` statement.
+The compiler must emit a ``CallError`` (see :ref:`sec:errors`) if a
+function is used in a ``call`` statement.
 
 A procedure may never be called within a function, doing so would allow for
 impure functions. Procedures may only be called within assignment statements
@@ -103,7 +103,7 @@ These restrictions are made by *Gazprea* in order to allow for more
 optimizations.
 
 Procedures without a return clause may not be used in an expression.
-*Gazprea* must emit a ``CallError`` in such a case.
+The compiler must emit a ``CallError`` in such a case.
 ::
 
          /* p is some procedure with no return clause */

--- a/gazprea/spec/procedures.rst
+++ b/gazprea/spec/procedures.rst
@@ -80,7 +80,8 @@ These procedures can be called as follows:
 Only procedures may be called with ``call``. Functions must
 appear in expressions because they can not cause side effects, so using
 a function in a ``call`` statement would not do anything. *Gazprea*
-should raise an error if a function is used in a ``call`` statement.
+must raise a ``CallError`` (see :ref:`sec:errors`) if a function is used in
+a ``call`` statement.
 
 A procedure may never be called within a function, doing so would allow for
 impure functions. Procedures may only be called within assignment statements
@@ -102,7 +103,7 @@ These restrictions are made by *Gazprea* in order to allow for more
 optimizations.
 
 Procedures without a return clause may not be used in an expression.
-*Gazprea* should raise an error in such a case.
+*Gazprea* must raise a ``CallError`` in such a case.
 ::
 
          /* p is some procedure with no return clause */
@@ -176,8 +177,8 @@ In *Gazprea* a program that aliases mutable variables is
 :term:`ill-formed`.  The only case
 where aliasing of arguments is allowed is through disjoint tuple or struct field access. This
 helps *Gazprea* compilers perform more optimizations. However, the compiler must be able
-to catch cases where mutable memory locations are aliased, and an error
-should be raised when this is detected. For instance:
+to catch cases where mutable memory locations are aliased, and an
+``AliasingError`` must be raised when this is detected. For instance:
 
 ::
 

--- a/gazprea/spec/statements.rst
+++ b/gazprea/spec/statements.rst
@@ -101,7 +101,8 @@ The types of the variables must match the types of the tuple’s fields,
 or the tuple’s fields must be able to be automatically promoted to the
 variable’s type. The number of variables in the comma separated list
 must match the number of fields in the tuple, if this is not the case an
-error should be raised. This assignment is performed left-to-right.
+``AssignError`` (see :ref:`sec:errors`) must be raised. This assignment is
+performed left-to-right.
 
 Assignments and initializations must perform a deep copy. It should not
 be possible to cause the aliasing of memory locations with an
@@ -128,7 +129,7 @@ arrays and tuples.
 
 Variables may be declared as const, and in this case a program that
 places them on the left hand side of an assignment expression is
-:term:`ill-formed`.  The compiler should raise an error when this is
+:term:`ill-formed`.  The compiler must raise an ``AssignError`` when this is
 detected, since it does not make sense to change a constant value.
 
 The right hand side of an assignment statement is always evaluated
@@ -432,8 +433,8 @@ actually contains the ``break``.
            "\n" -> std_output;
          }
 
-If a ``break`` statement is not contained within a loop an error must be
-raised.
+If a ``break`` statement is not contained within a loop a
+``StatementError`` must be raised.
 
 .. _ssec:statements_continue:
 

--- a/gazprea/spec/statements.rst
+++ b/gazprea/spec/statements.rst
@@ -100,9 +100,9 @@ variable. For instance:
 The types of the variables must match the types of the tuple’s fields,
 or the tuple’s fields must be able to be automatically promoted to the
 variable’s type. The number of variables in the comma separated list
-must match the number of fields in the tuple, if this is not the case an
-``AssignError`` (see :ref:`sec:errors`) must be raised. This assignment is
-performed left-to-right.
+must match the number of fields in the tuple, if this is not the case the
+compiler must emit an ``AssignError`` (see :ref:`sec:errors`). This
+assignment is performed left-to-right.
 
 Assignments and initializations must perform a deep copy. It should not
 be possible to cause the aliasing of memory locations with an
@@ -129,7 +129,7 @@ arrays and tuples.
 
 Variables may be declared as const, and in this case a program that
 places them on the left hand side of an assignment expression is
-:term:`ill-formed`.  The compiler must raise an ``AssignError`` when this is
+:term:`ill-formed`.  The compiler must emit an ``AssignError`` when this is
 detected, since it does not make sense to change a constant value.
 
 The right hand side of an assignment statement is always evaluated
@@ -387,7 +387,8 @@ expression do not affect the captured domain.  For instance:
              i -> std_output; "\n" -> std_output;
            }
 
-Note that multiple domain expressions are *not* allowed:
+Note that multiple domain expressions are *not* allowed; an iterator
+loop with more than one domain expression must emit a ``SyntaxError``.
 
 ::
 
@@ -433,8 +434,8 @@ actually contains the ``break``.
            "\n" -> std_output;
          }
 
-If a ``break`` statement is not contained within a loop a
-``StatementError`` must be raised.
+If a ``break`` statement is not contained within a loop the compiler must
+emit a ``StatementError``.
 
 .. _ssec:statements_continue:
 
@@ -446,7 +447,8 @@ a loop. When a ``continue`` statement is executed the innermost loop
 that contains the ``continue`` statements starts its next iteration.
 ``continue`` stops the execution of the loop’s body statement, the loop
 then continues as though the body statement finished its execution
-normally.
+normally. If a ``continue`` statement is not contained within a loop the
+compiler must emit a ``StatementError``.
 
 ::
 

--- a/gazprea/spec/type_qualifiers.rst
+++ b/gazprea/spec/type_qualifiers.rst
@@ -45,7 +45,7 @@ For example:
 
      var integer i;
 
-The compiler must raise an ``AssignError`` (see :ref:`sec:errors`) if an
+The compiler must emit an ``AssignError`` (see :ref:`sec:errors`) if an
 attempt is made to modify a variable that is not explicitly declared
 ``var``.
 

--- a/gazprea/spec/type_qualifiers.rst
+++ b/gazprea/spec/type_qualifiers.rst
@@ -45,8 +45,9 @@ For example:
 
      var integer i;
 
-The compiler should raise an error if an attempt is made to modify a variable
-that is not explicitly declared ``var``.
+The compiler must raise an ``AssignError`` (see :ref:`sec:errors`) if an
+attempt is made to modify a variable that is not explicitly declared
+``var``.
 
 .. _ssec:typeQualifiers_infer:
 

--- a/gazprea/spec/typedef.rst
+++ b/gazprea/spec/typedef.rst
@@ -55,7 +55,7 @@ Because a ``typealias`` is an aliased name for a type, you can use
   typealias integer int;
   typealias int also_int;
 
-Duplicate alias names must raise a ``SymbolError`` (see :ref:`sec:errors`).
+Duplicate alias names must emit a ``SymbolError`` (see :ref:`sec:errors`).
 
 ::
 
@@ -75,8 +75,8 @@ folding of scalar literals but also constant propagation through other
     vec_of_two v = 1..3;
   }
 
-Should raise a ``SizeError`` on line 3 since the ``vec_of_two`` type has a size
-of 2 and an array of size 3 is being assigned.
+The compiler must emit a ``SizeError`` on line 3 since the ``vec_of_two``
+type has a size of 2 and an array of size 3 is being assigned.
 
 Because the size may be any ``constexpr``, it can reference other constant
 expressions rather than being limited to literals:

--- a/gazprea/spec/typedef.rst
+++ b/gazprea/spec/typedef.rst
@@ -55,7 +55,7 @@ Because a ``typealias`` is an aliased name for a type, you can use
   typealias integer int;
   typealias int also_int;
 
-Duplicate alias names should raise a `SymbolError`
+Duplicate alias names must raise a ``SymbolError`` (see :ref:`sec:errors`).
 
 ::
 

--- a/gazprea/spec/types/array.rst
+++ b/gazprea/spec/types/array.rst
@@ -50,8 +50,8 @@ array instead of a ``real`` array.
    with the RHS element type's initialization semantics applying from left to right.
    If the LHS array is initialized using a RHS array that is too small then the LHS array will
    be padded with zeros. However, if the LHS array is initialized with a RHS
-   array that is too large then a ``SizeError`` (see :ref:`sec:errors`) must
-   be thrown at :term:`compile time` or :term:`run time`.
+   array that is too large then the compiler must emit a ``SizeError``
+   (see :ref:`sec:errors`) at :term:`compile time` or :term:`run time`.
 
 #. Inferred Size Declarations
 
@@ -280,8 +280,7 @@ Operations
          integer x = v[-2]; /* x == 5 */
          integer y = [4,5,6][-1] /* y == 6 */
 
-      Out of bounds indexing must cause an ``IndexError``
-      (see :ref:`sec:errors`).
+      Out of bounds indexing must emit an ``IndexError``.
 
    e. Stride
 
@@ -363,7 +362,7 @@ Operations
 
 
    Attempting to perform a binary operation between two arrays of
-   different sizes should result in a ``SizeError``.
+   different sizes must emit a ``SizeError``.
 
    When one of the operands of a binary operation is an array and the
    other operand is a scalar, the scalar value must first

--- a/gazprea/spec/types/array.rst
+++ b/gazprea/spec/types/array.rst
@@ -280,7 +280,8 @@ Operations
          integer x = v[-2]; /* x == 5 */
          integer y = [4,5,6][-1] /* y == 6 */
 
-      Out of bounds indexing should cause an error.
+      Out of bounds indexing must cause an ``IndexError``
+      (see :ref:`sec:errors`).
 
    e. Stride
 

--- a/gazprea/spec/types/array.rst
+++ b/gazprea/spec/types/array.rst
@@ -50,8 +50,8 @@ array instead of a ``real`` array.
    with the RHS element type's initialization semantics applying from left to right.
    If the LHS array is initialized using a RHS array that is too small then the LHS array will
    be padded with zeros. However, if the LHS array is initialized with a RHS
-   array that is too large then a ``SizeError`` should be thrown at
-   :term:`compile time` or :term:`run time`.
+   array that is too large then a ``SizeError`` (see :ref:`sec:errors`) must
+   be thrown at :term:`compile time` or :term:`run time`.
 
 #. Inferred Size Declarations
 

--- a/gazprea/spec/types/matrix.rst
+++ b/gazprea/spec/types/matrix.rst
@@ -35,8 +35,8 @@ All rows with fewer elements than the row of maximum row length are padded with
 zeros on the right. Similarly, if the matrix is declared with a row
 length larger than the number of rows provided, the bottom rows of the
 matrix are zero. If the number of rows or columns exceeds the
-amounts given in a declaration a ``SizeError`` (see :ref:`sec:errors`) is
-to be produced.
+amounts given in a declaration the compiler must emit a ``SizeError``
+(see :ref:`sec:errors`).
 
 ::
 
@@ -87,7 +87,7 @@ multiplication.
 Specifically, the number of columns of the first operand must equal the number
 of rows of the second operand, e.g. an :math:`m \times n` matrix multiplied by
 an :math:`n \times p` matrix will produce an :math:`m \times p` matrix.
-If the dimensions are not correct a ``SizeError`` should be raised.
+If the dimensions are not correct the compiler must emit a ``SizeError``.
 
 Arrays of any dimension support the built in functions ``rows`` and ``columns``,
 which when passed a 2D array yields the number of rows and columns in the
@@ -120,7 +120,8 @@ and column. Both the row and column indices must be integers.
 
            /* M[1][2] == 12 */
 
-As with arrays, out of bounds indexing on matrices is an ``IndexError``.
+As with arrays, out of bounds indexing on matrices must emit an
+``IndexError``.
 
 
 Type Casting and Type Promotion

--- a/gazprea/spec/types/matrix.rst
+++ b/gazprea/spec/types/matrix.rst
@@ -35,7 +35,8 @@ All rows with fewer elements than the row of maximum row length are padded with
 zeros on the right. Similarly, if the matrix is declared with a row
 length larger than the number of rows provided, the bottom rows of the
 matrix are zero. If the number of rows or columns exceeds the
-amounts given in a declaration an error is to be produced.
+amounts given in a declaration a ``SizeError`` (see :ref:`sec:errors`) is
+to be produced.
 
 ::
 
@@ -119,7 +120,7 @@ and column. Both the row and column indices must be integers.
 
            /* M[1][2] == 12 */
 
-As with arrays, out of bounds indexing is an error on Matrices.
+As with arrays, out of bounds indexing on matrices is an ``IndexError``.
 
 
 Type Casting and Type Promotion

--- a/gazprea/spec/types/struct.rst
+++ b/gazprea/spec/types/struct.rst
@@ -131,7 +131,8 @@ This allows struct instances to be compared to struct literals:
      if (c == Complex(r: 0.0, i: i)) { }
 
 Two structs are equal when all fields within each struct have the same value.
-It is an error to compare two structs of different types.
+Comparing two structs of different types is a ``TypeError``
+(see :ref:`sec:errors`).
 
 Type Casting and Type Promotion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gazprea/spec/types/struct.rst
+++ b/gazprea/spec/types/struct.rst
@@ -131,7 +131,7 @@ This allows struct instances to be compared to struct literals:
      if (c == Complex(r: 0.0, i: i)) { }
 
 Two structs are equal when all fields within each struct have the same value.
-Comparing two structs of different types is a ``TypeError``
+Comparing two structs of different types must emit a ``TypeError``
 (see :ref:`sec:errors`).
 
 Type Casting and Type Promotion


### PR DESCRIPTION
**PR #9 in the spec-review stack.** Names the error class at every rule that
previously said only "an error", so students (and the tester) can tell what
class and phase each rule commits the compiler to.

## What

Three commits on `feat/errors-chapter`:

1.  `fix(gazprea): name error classes at anonymous error sites` (2157442).
    The impl chapter (`sec:errors`) defines the full taxonomy; a dozen spec
    rules named none of it. Each site now names its class, and the first
    mention in each file cross-references `sec:errors`. Also normalizes
    "should raise" → "must raise" at these sites.

2.  `fix(gazprea): add missing sec:errors cross-refs at first-mentions`
    (282e529). Fixes two sites the first pass missed:
    - `typedef.rst:57` — `SymbolError` on duplicate aliases (also fixes a
      literal-role typo that would have rendered as an unresolved title-ref).
    - `types/array.rst:53` — moves the first-mention cross-ref onto the
      earliest `SizeError` in that file.

3.  `fix(gazprea): fill omitted error sites and unify on "must emit"`
    (39fee75). Three coordinated cleanups kept in one commit:
    - Fills nine omitted classifications: `ReturnError` on the "return
      reachable by all paths" rule; a `GlobalError` summary covering
      non-constexpr init / vector globals / non-global statements;
      `StatementError` for a declaration outside the leading declaration
      block; `SyntaxError` for iterator loops with more than one domain;
      `StatementError` for `continue` outside a loop; and `SyntaxError` for
      type-qualified function arguments.
    - Normalizes two residual "should raise" sites in files the first pass
      already touched: matmul dimension mismatch (`types/matrix.rst:90`) and
      elementwise binop size mismatch (`types/array.rst:361`). Also
      normalizes `typedef.rst:77`'s inline "Should raise a `SizeError`"
      callout while the file was open.
    - Unifies every patch-touched site on **"must emit a `X`"** (active or
      passive). The first pass used six different verbs at otherwise
      identical sites (`issue` / `raise` / `yield` / `cause` / `is` / `is to
      be produced`); one verb reads consistently and matches how the errors
      chapter itself describes the requirement. Also drops a redundant
      `(see :ref:`sec:errors`)` on `types/array.rst:279` now that
      `types/array.rst:53` carries the first-mention ref.

## What is NOT in this PR

- **`expressions.rst:54`** (generator with wrong number of domain
  variables) stays classed as `SyntaxError`. Making the semantic-phase
  argument here would be a substantive spec change and belongs in a
  separate PR, not this normalization pass.
- **Rest-of-file rewordings.** The "must emit" convergence is scoped to
  sites the patch already touched (plus the two residuals called out in
  commit 3's body). A repo-wide sweep, if wanted, is a follow-up.

## Signatures

All three commits signed with the agent's session key
(`F38D8669…FAC880`); public key vendored at `.agents/agent-pubkey.asc`
via PR #110.