### PR TITLE
[stack 3/20] spec(gazprea): state the vector element-type set

### DIFF
--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -26,8 +26,13 @@ the literals ``<`` and ``>`` are used in the declaration)
 
 
 Unlike the array type, *Gazprea* vectors do not have an explicit size
-specifier, often called *capacity* in other languages. Below are some examples of 
-`vector` declarations.
+specifier, often called *capacity* in other languages.
+
+The element type ``T`` of a ``vector<T>`` may be any base type
+(``boolean``, ``character``, ``integer``, ``real``) or a one-dimensional
+array of a base type. Vectors of vectors, tuples, structs, strings, and
+streams are not permitted. Below are some examples of
+``vector`` declarations.
    
     ::
 

--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -29,7 +29,7 @@ Unlike the array type, *Gazprea* vectors do not have an explicit size
 specifier, often called *capacity* in other languages.
 
 The element type ``T`` of a ``vector<T>`` may be any base type
-(``boolean``, ``character``, ``integer``, ``real``) or a one-dimensional
+(``boolean``, ``integer``, ``real``, ``character``) or a one-dimensional
 array of a base type. Vectors of vectors, tuples, structs, strings, and
 streams are not permitted. Below are some examples of
 ``vector`` declarations.


### PR DESCRIPTION
**PR #23 in the spec-review stack.** Single-commit patch.

## What

`vector<T>` never said which `T` are legal, leaving `vector<vector<T>>`,
`vector<tuple(...)>`, and `vector<string>` undecidable. The patch adds
a one-sentence rule: `T` is a base type (`boolean`, `character`,
`integer`, `real`) or a 1-D array of a base type. This matches every
existing `vector<T>` example in the spec.

## Verification

Audit confirmed the rule is consistent with every extant use:

- `types/vector.rst:34-51` — T ∈ `{integer[2], integer, real,
  character, real[*], real[2]}` — all base types or 1-D arrays.
- `types/vector.rst:71,83` — `integer`, `real[2]` — conform.
- `functions.rst:194` — `vector<real>` — conforms.
- `constexpr.rst:126` — `vector<integer>` — conforms.
- `types/string.rst:7` — string is "a vector of character"; `character`
  is a base type, so consistent.

No `vector<vector<...>>`, `vector<string>`, `vector<tuple(...)>`, or
`vector<struct>` examples exist anywhere in the spec, so nothing breaks.

## What is NOT in this PR

Four small clarifications the reviewer surfaced are deliberately
deferred as separate polish, not required for correctness:

- Whether "base type" should be a named term the spec defines once and
  reuses.
- An explicit note that the ban is on the *container* (a `string`
  value can still round-trip through `vector<character>` via
  `type_promotion.rst:123`).
- Confirmation that `vector<T[n]>` / `vector<T[*]>` is the intended
  2-D-ish container (contrasted with `matrix`).
- An explicit note that the element-type restriction does not affect
  `string` itself (string is its own type).

## Signatures

Signed with the agent's session key (`F38D8669…FAC880`); public key
vendored via PR #110.