### PR TITLE
[stack 5/20] spec(gazprea): distinguish range slices from array-valued indices

### DIFF
--- a/gazprea/spec/statements.rst
+++ b/gazprea/spec/statements.rst
@@ -45,9 +45,10 @@ promoted to the type of the variable. For instance:
 Assignments can also be more complicated than this with arrays and tuples.
 With arrays indices may be provided in order to change the value of an array
 element. In *Gazprea*, an array cannot be indexed with an array *value*:
-``v[w]`` is illegal when ``w`` is an array variable, even one holding a
-range. Range syntax written directly inside an index position is not an
-array-valued index; it forms a slice
+``v[w]`` is illegal whenever ``w`` evaluates to an array value, even one
+holding a range (this covers array variables, expressions, and function
+calls that return an array alike). Range syntax written directly inside
+an index position is not an array-valued index; it forms a slice
 (see :ref:`sssec:array_slices`).
 For instance, with single dimensional arrays:
 

--- a/gazprea/spec/statements.rst
+++ b/gazprea/spec/statements.rst
@@ -44,7 +44,11 @@ promoted to the type of the variable. For instance:
 
 Assignments can also be more complicated than this with arrays and tuples.
 With arrays indices may be provided in order to change the value of an array
-element. In Gazprea, arrays cannot be indexed with array expressions.
+element. In *Gazprea*, an array cannot be indexed with an array *value*:
+``v[w]`` is illegal when ``w`` is an array variable, even one holding a
+range. Range syntax written directly inside an index position is not an
+array-valued index; it forms a slice
+(see :ref:`sssec:array_slices`).
 For instance, with single dimensional arrays:
 
 ::

--- a/gazprea/spec/types/array.rst
+++ b/gazprea/spec/types/array.rst
@@ -257,7 +257,11 @@ Operations
    d. Indexing
 
       An array may be indexed in order to retrieve the values stored in
-      the array. An array may be indexed using integers.
+      the array. An array may be indexed using an integer, in which case
+      the index yields a single element, or using range syntax written
+      directly at the index position, in which case the index yields a
+      slice (see :ref:`sssec:array_slices`). An array *value* — including
+      a range bound to a variable — is not a legal index.
       *Gazprea* is 1-indexed, so the first element of an array is at index 1
       (as opposed to index 0 in languages like *C*). For instance:
 


### PR DESCRIPTION
**PR #13 in the spec-review stack.** Two commits on `fix/range-index-semantics`.

## What

1.  `fix(gazprea): distinguish range slices from array-valued indices`
    (ebe5f8d). The old rule "arrays cannot be indexed with array
    expressions" collided with two facts the spec already relied on:
    ranges are arrays, and slicing is defined as indexing by a range.
    The rule in `statements.rst` now names the distinction: array
    values (including ranges bound to variables) are illegal indices;
    literal range syntax written directly at an index position is the
    slice form.

2.  `fix(gazprea): reconcile the array indexing rule with the slice
    form` (07cf0f2). Follow-up. `types/array.rst`'s indexing
    subsection still said "An array may be indexed using integers",
    which continued to contradict the very next subsection defining
    slices as indexing by a range. Extend it to match `statements.rst`:
    integer indices yield elements, range-at-index-position yields a
    slice (with a cross-reference to the slices subsection), array
    *values* are illegal indices.

## What is NOT in this PR

- **Matrix indexing.** `types/matrix.rst:103` still says "Both the row
  and column indices must be integers", which forecloses matrix
  slicing entirely. The reviewer flagged this as a parallel omission,
  but it's a substantive question — is matrix slicing intended to
  exist? — not a normalization, so it belongs in a separate PR after
  a decision.

- **Formal definition of "range syntax".** The new prose is
  syntactic ("range syntax written directly"). The spec never formally
  distinguishes "range syntax" from "range expression". Edge cases
  (a range with `by`, a parenthesized range, a range returned from a
  function) are unspecified. A follow-up could formalize this if the
  distinction turns out to matter for the parser.

- **Interaction with `by`.** `types/array.rst:308` says "for slicing
  the range always has a stride of 1"; the new statements.rst
  language doesn't restate that. Not contradictory, but the two
  rules live in different chapters and might drift.

## Signatures

Both commits signed with the agent's session key (`F38D8669…FAC880`);
public key vendored via PR #110.