### PR TITLE
[stack 6/20] spec(gazprea): scope the promotion-implies-cast claim

### DIFF
--- a/gazprea/spec/type_promotion.rst
+++ b/gazprea/spec/type_promotion.rst
@@ -13,7 +13,7 @@ scalar-to-array *cast* must state the destination size explicitly
 (:ref:`ssec:typeCasting_stovm`), whereas the corresponding *promotion*
 infers the size from the array operand. Second, the
 ``string``/``character[*]`` conversion is an implicit two-way promotion
-with no ``as<>`` form (see the final section of this chapter).
+with no ``as<>`` form (see :ref:`ssec:typePromotion_string`).
 
 Note that there is no implicit promotion from a one-dimensional array to a
 two-dimensional array: only scalars broadcast, to arrays and to matrices
@@ -126,6 +126,8 @@ It is possible for a two sided promotion to occur with tuples. For example:
 ::
 
   boolean b = (1.0, 2) == (2, 3.0);
+
+.. _ssec:typePromotion_string:
 
 Character Array to/from String
 -------------------------------

--- a/gazprea/spec/type_promotion.rst
+++ b/gazprea/spec/type_promotion.rst
@@ -7,10 +7,17 @@ Type Promotion
 It is deliberately distinct from :ref:`type casting <sec:typeCasting>`,
 which is the explicit mechanism invoked via ``as<toType>(value)``.
 
-Any conversion that can be done implicitly via promotion can also be
-done explicitly via a typecast expression.  The notable exception is
-array promotion to a higher dimension, which occurs as a consequence of
-scalar to array promotion.
+Most conversions that can be done implicitly via promotion can also be done
+explicitly via a typecast expression. There are two caveats. First, a
+scalar-to-array *cast* must state the destination size explicitly
+(:ref:`ssec:typeCasting_stovm`), whereas the corresponding *promotion*
+infers the size from the array operand. Second, the
+``string``/``character[*]`` conversion is an implicit two-way promotion
+with no ``as<>`` form (see the final section of this chapter).
+
+Note that there is no implicit promotion from a one-dimensional array to a
+two-dimensional array: only scalars broadcast, to arrays and to matrices
+alike.
 
 .. _ssec:typePromotion_scalar:
 
@@ -75,9 +82,11 @@ Other examples:
 
 Note that an array can never be downcast to a scalar,
 even if type casting is used. Also note that matrix multiply imposes strict
-requirements on the dimensionality of the the operands. The consequence is
-that scalars can only be promoted to a matrix if the matrix multiply
-operand is a square matrix (:math:`m \times m`).
+requirements on the dimensionality of the operands. The consequence is
+that, *as an operand of matrix multiplication* (``**``), a scalar can only
+be promoted to a matrix when the other operand is a square matrix
+(:math:`m \times m`). In element-wise operations and initializations a
+scalar broadcasts to a matrix of any shape.
 
 Tuple to Tuple
 --------------
@@ -121,7 +130,12 @@ It is possible for a two sided promotion to occur with tuples. For example:
 Character Array to/from String
 -------------------------------
 
-A ``string`` can be implicitly converted to a vector of ``character``\ s and vice-versa (two-way type promotion).
+A ``string`` can be implicitly converted to a ``character`` array
+(``character[*]``) and vice-versa (two-way type promotion). Because a
+``string`` is itself a vector of ``character`` (see :ref:`ssec:string`),
+the conversion of note is between ``string`` and character *arrays*; a
+``string`` used where a character array is expected, or vice-versa,
+converts silently.
 
 ::
 

--- a/gazprea/spec/type_promotion.rst
+++ b/gazprea/spec/type_promotion.rst
@@ -86,7 +86,7 @@ requirements on the dimensionality of the operands. The consequence is
 that, *as an operand of matrix multiplication* (``**``), a scalar can only
 be promoted to a matrix when the other operand is a square matrix
 (:math:`m \times m`). In element-wise operations and initializations a
-scalar broadcasts to a matrix of any shape.
+scalar broadcasts to a matrix of any dimensions.
 
 Tuple to Tuple
 --------------
@@ -133,9 +133,7 @@ Character Array to/from String
 A ``string`` can be implicitly converted to a ``character`` array
 (``character[*]``) and vice-versa (two-way type promotion). Because a
 ``string`` is itself a vector of ``character`` (see :ref:`ssec:string`),
-the conversion of note is between ``string`` and character *arrays*; a
-``string`` used where a character array is expected, or vice-versa,
-converts silently.
+the conversion of note is between ``string`` and character *arrays*.
 
 ::
 


### PR DESCRIPTION
**PR #15 in the spec-review stack.** Two commits on `fix/promotion-cast-claim`.

## What

1.  `fix(gazprea): scope the promotion-implies-cast claim` (c087971).
    The universal claim was false for `string`/`character[*]` (no
    `as<>` form exists) and glossed the size requirement on
    scalar-to-array casts. The vague "higher dimension" exception is
    replaced with the concrete rule (no 1-D to 2-D promotion; scalars
    broadcast), the square-matrix note is scoped to `**` operands, and
    the string promotion section now names the array/vector distinction
    precisely.

2.  `fix(gazprea): drop stdlib "shape" noun and trim redundant clause`
    (537f890). Two follow-ups on top of the first commit:
    - The scalar-to-matrix promotion note said "a matrix of any
      shape". `shape` is a stdlib extension in this project, not part
      of the formal spec (companion patch scopes it out); the noun
      here is swapped to "of any dimensions" to avoid conflation with
      the stdlib name.
    - The added tail clause in the Character-Array/String section
      ("converts silently") duplicated "implicitly converted" from
      the sentence above. Trimmed; the "of note is between ``string``
      and character *arrays*" pointer still carries the intended
      emphasis.

## What is NOT in this PR

- **`type_casting.rst:48`** — the old prose there ("A scalar may be
  *promoted* to an array of any dimension…") uses "promoted" while
  describing an explicit `as<>` cast, propagating the same
  promote/cast conflation this patch is fixing. Not addressed here —
  the section is a companion cleanup that belongs on its own branch so
  the diff stays scoped.
- **`type_casting.rst:95`** — "Conversions between arrays of any
  dimension are possible" (array→array cast). Doesn't contradict this
  patch (which restricts *promotion*, not casts), but worth
  confirming whether 1-D↔2-D explicit cast is actually intended
  before touching it.

## Signatures

Both commits signed with the agent's session key (`F38D8669…FAC880`);
public key vendored via PR #110.