### PR TITLE
[stack 4/20] spec(gazprea): scope the vector-array equivalence claim

### DIFF
--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -4,10 +4,15 @@ Vectors
 -------
 
 Vectors are language supported objects that allow for dynamically sized arrays.
-Once created, ``vectors`` in *Gazprea* behave exactly like arrays: they can be
-intermixed with arrays in expressions; they can be used on the RHS of array
-declarations and initializations; and they can be passed as array arguments to
-subroutines and functions.
+Once created, ``vectors`` in *Gazprea* interoperate freely with arrays: they
+can be intermixed with arrays in expressions; they can be used on the RHS of
+array declarations and initializations; and they can be passed as array
+arguments to functions and procedures. Vectors are nevertheless a distinct
+type, and the differences are normative: vectors have methods where arrays
+have none, binary operations involving a vector produce *array* results,
+and a vector of inferred-size arrays pads to the size of its *first*
+element (see below), whereas a matrix literal pads to its longest row
+(see :ref:`sssec:matrix_constr`).
 
 .. _sssec:vec_decl:
 
@@ -46,7 +51,10 @@ streams are not permitted. Below are some examples of
 
 Vectors of inferred sized arrays assume the size of the *first* array in the vector.
 Subsequent array elements of less than the inferred size are padded.
-Those greater raise a :term:`run time` ``SizeError``.
+Those greater raise a :term:`run time` ``SizeError``. (Contrast with
+:ref:`matrix construction <sssec:matrix_constr>`, where rows pad to the
+*longest* row: the same nested literal can be legal as a matrix and a
+``SizeError`` as a vector of arrays.)
 
    ::
 

--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -9,10 +9,10 @@ can be intermixed with arrays in expressions; they can be used on the RHS of
 array declarations and initializations; and they can be passed as array
 arguments to functions and procedures. Vectors are nevertheless a distinct
 type, and the differences are normative: vectors have methods where arrays
-have none, binary operations involving a vector produce *array* results,
-and a vector of inferred-size arrays pads to the size of its *first*
-element (see below), whereas a matrix literal pads to its longest row
-(see :ref:`sssec:matrix_constr`).
+have none, a mixed binary operation between a vector and an array produces
+an *array* result, and a vector of inferred-size arrays pads to the size
+of its *first* element (see below), whereas a matrix literal pads to its
+longest row (see :ref:`sssec:matrix_constr`).
 
 .. _sssec:vec_decl:
 
@@ -67,9 +67,11 @@ Those greater raise a :term:`run time` ``SizeError``. (Contrast with
 Operations
 ~~~~~~~~~~~
 
-Operations on vectors are identical syntactically and semantically to
-operations on arrays. In particular, operand lengths must match for binary
-expressions and dot product. All binary operations between vector and arrays produce array results.
+Operations on vectors use the same syntax as operations on arrays and,
+except for the differences enumerated above, share their semantics.
+In particular, operand lengths must match for binary expressions and dot
+product. All binary operations between a vector and an array produce
+array results.
 
 As a language supported object, *Gazprea* provides several methods for ``vector``:
 

--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -4,11 +4,12 @@ Vectors
 -------
 
 Vectors are language supported objects that allow for dynamically sized arrays.
-Once created, ``vectors`` in *Gazprea* interoperate freely with arrays: they
-can be intermixed with arrays in expressions; they can be used on the RHS of
-array declarations and initializations; and they can be passed as array
-arguments to functions and procedures. Vectors are nevertheless a distinct
-type, and the differences are normative: vectors have methods where arrays
+Once created, ``vectors`` in *Gazprea* interoperate with arrays for the
+element types they both support: they can be intermixed with arrays in
+expressions; they can be used on the RHS of array declarations and
+initializations; and they can be passed as array arguments to functions
+and procedures. Vectors are nevertheless a distinct type, and the
+differences include (non-exhaustively): vectors have methods where arrays
 have none, a mixed binary operation between a vector and an array produces
 an *array* result, and a vector of inferred-size arrays pads to the size
 of its *first* element (see below), whereas a matrix literal pads to its


### PR DESCRIPTION
**PR #12 in the spec-review stack.** Two commits on `fix/vector-array-divergence`.

## What

1.  `fix(gazprea): scope the vector-array equivalence claim` (ab6eeed).
    "Vectors behave exactly like arrays" papered over normative
    differences the same file relied on: methods, array-valued binary
    results, and a pad-to-first ragged policy that contradicts matrix
    pad-to-longest for the same literal. The claim becomes an interop
    list plus explicit enumeration of the differences, with a
    cross-reference at the padding rule. Also replaces the undefined
    term "subroutines" with "functions and procedures".

2.  `fix(gazprea): keep vector/array claims consistent between intro
    and body` (de3d751). Two lingering over-broad claims in
    `types/vector.rst`:
    - The intro's differences list said "binary operations *involving
      a vector* produce array results", but the body (the "Operations"
      subsection just below) only supports that for *mixed*
      vector+array operations. The vector+vector case isn't stated
      anywhere. Narrow the intro to match the body.
    - The Operations subsection opened with "Operations on vectors
      are identical syntactically **and semantically** to operations
      on arrays" — the exact over-broad equivalence the patch is
      scoping out of the intro. Left in place, it re-introduces the
      paperover a few lines down. Reword so the enumeration in the
      intro remains authoritative.

## Padding-policy check

The cross-reference target `sssec:matrix_constr` is defined at
`types/matrix.rst:27`, directly above the pad-to-longest prose. Both
policies are correctly cited: vector pad-to-first at
`types/vector.rst:44-46`, matrix pad-to-longest at
`types/matrix.rst:32-38`.

## What is NOT in this PR

- **`types/string.rst:8`** ("like a vector, a string behaves like a
  dynamically sized array") leans on the same loose equivalence one
  step removed. Low priority — the surrounding prose in string.rst
  already self-scopes, and touching it would widen this PR's blast
  radius beyond the vector file.

## Signatures

Both commits signed with the agent's session key (`F38D8669…FAC880`);
public key vendored via PR #110.