### PR TITLE
[stack 7/20] spec(gazprea): single home for operator precedence

### DIFF
--- a/gazprea/spec/expressions.rst
+++ b/gazprea/spec/expressions.rst
@@ -12,7 +12,9 @@ Table of Operator precedence
 ----------------------------
 
 The following is a table containing all of the precedences and
-associativities of the operators in *Gazprea*.
+associativities of the operators in *Gazprea*. Parentheses are not
+listed: they do not participate in the precedence relation and instead
+override it by grouping their contents into a new atom.
 
 +----------------+------------------------------------+-------------------+
 | **Precedence** | **Operators**                      | **Associativity** |

--- a/gazprea/spec/types/boolean.rst
+++ b/gazprea/spec/types/boolean.rst
@@ -52,25 +52,9 @@ evaluation <https://en.wikipedia.org/wiki/Short-circuit_evaluation>`__.
 Therefore, both the left hand side and right hand side of an expression
 must always be evaluated.
 
-This table specifies ``boolean`` operator precedence. Operators without
-lines between them have the same level of precedence.
-
-+----------------+---------------+
-| **Precedence** | **Operation** |
-+================+===============+
-| HIGHER         | ``not``       |
-+----------------+---------------+
-|                | ``==``        |
-|                |               |
-|                | ``!=``        |
-+----------------+---------------+
-|                | ``and``       |
-+----------------+---------------+
-|                | ``or``        |
-|                |               |
-| LOWER          | ``xor``       |
-+----------------+---------------+
-
+Operator precedence and associativity are specified once, for all
+types, in the :ref:`table of operator precedence
+<ssec:expressions_toop>`.
 
 Type Casting and Type Promotion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gazprea/spec/types/integer.rst
+++ b/gazprea/spec/types/integer.rst
@@ -78,43 +78,9 @@ of remainder in *C99*.
 
 Exponentiation between integers gives an ``integer`` result. This is the same behavior as performing exponentiation on reals then truncating to an ``integer``.
 
-This table specifies ``integer`` operator precedence. Operators without
-lines between them have the same level of precedence. Note that
-parentheses are not included in this list because they are used to
-override precedence and create new atoms in an expression.
-
-+----------------+----------------+
-| **Precedence** | **Operations** |
-+================+================+
-| HIGHER         | ``unary +``    |
-|                |                |
-|                | ``unary -``    |
-+----------------+----------------+
-|                | ``^``          |
-+----------------+----------------+
-|                | ``*``          |
-|                |                |
-|                | ``/``          |
-|                |                |
-|                | ``%``          |
-+----------------+----------------+
-|                | ``+``          |
-|                |                |
-|                | ``-``          |
-+----------------+----------------+
-|                | ``<``          |
-|                |                |
-|                | ``>``          |
-|                |                |
-|                | ``<=``         |
-|                |                |
-|                | ``>=``         |
-+----------------+----------------+
-|                | ``==``         |
-|                |                |
-| LOWER          | ``!=``         |
-+----------------+----------------+
-
+Operator precedence and associativity are specified once, for all
+types, in the :ref:`table of operator precedence
+<ssec:expressions_toop>`.
 
 Type Casting and Type Promotion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gazprea/spec/types/real.rst
+++ b/gazprea/spec/types/real.rst
@@ -53,7 +53,10 @@ multiplies the first literal by :math:`{10}^{x}`. For example,
 Operations
 ~~~~~~~~~~
 
-Floating point operations and precedence are equivalent to :ref:`integer operation and precedence <sssec:integer_ops>`.
+Floating point operations are equivalent to :ref:`integer operations
+<sssec:integer_ops>`. Operator precedence and associativity, as for all
+types, are specified once in the :ref:`table of operator precedence
+<ssec:expressions_toop>`.
 
 Operations on real numbers should adhere to the IEEE 754 spec with
 regards to the representation of not-a-number(NaNs), infinity(infs), and


### PR DESCRIPTION
**PR #17 in the spec-review stack.** Two commits.

## What

1.  `refactor(gazprea): single home for operator precedence` (7d238c0).
    Operator precedence existed in three copies (`expressions.rst`
    normative table + per-type tables in `types/integer.rst` and
    `types/boolean.rst`). The per-type copies are the divergence trap
    — any operator change had to land in all three. The per-type
    pages now delegate upward to the normative table in
    `expressions.rst`.

2.  `refactor(gazprea): flatten the precedence indirection and restore
    the parens note` (81432c9). Human-review polish:
    - `types/real.rst:55` still said "operations *and precedence* are
      equivalent to :ref:`integer operation and precedence
      <sssec:integer_ops>`". Post-refactor, `sssec:integer_ops` no
      longer contains a precedence table (it delegates upward),
      making this a two-hop indirection where the first hop no longer
      has what the sentence promises. Split the sentence: semantics
      still point at `sssec:integer_ops`; precedence points directly
      at the normative table.
    - The integer chapter's removed precedence paragraph carried a
      note that parentheses aren't in the list because they override
      precedence. That guidance is normative about the table, not
      integer-specific, so lift it into `expressions.rst` next to the
      table.

## Verified

Audit confirmed every operator in either per-type table survives in
the normative table; the three tables agreed pre-patch (integer:
`unary > ^ > */% > +/- > </>/<=/>= > ==/!=` maps onto normative
levels 4>5>6>7>9>10; boolean: `not > ==/!= > and > or/xor` maps onto
4>10>11>12); cross-refs resolve.

## What is NOT in this PR

- **`types/integer.rst:37+` still carries an Associativity column** in
  its (unrelated) Operations table, duplicating what the normative
  table now owns. Out of scope for this commit (which said "precedence
  only"); worth a follow-up.

## Signatures

Both commits signed with the agent's session key (`F38D8669…FAC880`);
public key vendored via PR #110.