### PR TITLE
[stack 9/20] spec(gazprea): single home for const-by-default rule

### DIFF
--- a/gazprea/spec/declarations.rst
+++ b/gazprea/spec/declarations.rst
@@ -16,7 +16,8 @@ A declaration creates a variable with an :ref:`identifier <sec:identifiers>` of
 The two qualifiers are ``var`` and ``const``, which qualify the identifier as
 *mutable* or *immutable*, respectively.
 In *Gazprea* it is important to remember that if the optional qualifier is
-omitted the default is ``const``, i.e. variables are immutable by default.
+omitted the default is ``const``, i.e. variables are immutable by default
+(normative statement in :ref:`sec:typeQualifiers`).
 
 Optionally, a declaration may explicitly initialize the value of the new
 variable with the value of ``<expression>``.

--- a/gazprea/spec/procedures.rst
+++ b/gazprea/spec/procedures.rst
@@ -7,7 +7,7 @@ A procedure in *Gazprea* is like a function, except that it does not
 have to be :term:`pure <functional purity>` and as a result it may:
 
 -  Have arguments marked with ``var`` that can be mutated. By default
-   arguments are ``const`` just like functions.
+   arguments are ``const`` just like functions (see :ref:`sec:typeQualifiers`).
 
 -  A procedure may only accept a literal or expression as an argument if
    and only if the procedure declares that argument as ``const``.

--- a/gazprea/spec/type_inference.rst
+++ b/gazprea/spec/type_inference.rst
@@ -26,9 +26,9 @@ automatically give x an integer type. A *Gazprea* programmer can use
 expression, as long as the compiler can guess the type for the
 expression.
 
-Note that although the qualifier may be elided (default is ``const``) and
-the type may be elided (inferred from the RHS), a declaration that
-elides both is :term:`ill-formed`:
+Note that although the qualifier may be elided (default is ``const``; see
+:ref:`sec:typeQualifiers`) and the type may be elided (inferred from the
+RHS), a declaration that elides both is :term:`ill-formed`:
 
 ::
 

--- a/gazprea/spec/type_qualifiers.rst
+++ b/gazprea/spec/type_qualifiers.rst
@@ -24,8 +24,11 @@ can be an rvalue. For example:
 Because a ``const`` value is not an lvalue, it cannot be passed to a
 ``var`` argument in a ``procedure``.
 
-Note that ``const`` is the default *Gazprea* behaviour and is essentially a
-no-op unless it is entirely replacing the type.
+``const`` is the default in *Gazprea*: a declaration with no qualifier
+declares a ``const`` variable. This section is the normative home of that
+rule; other chapters reference it. Writing ``const`` explicitly is
+therefore redundant, except where the qualifier entirely replaces the
+type (the inference form below).
 
 
 .. _ssec:typeQualifiers_var:

--- a/gazprea/spec/type_qualifiers.rst
+++ b/gazprea/spec/type_qualifiers.rst
@@ -25,10 +25,12 @@ Because a ``const`` value is not an lvalue, it cannot be passed to a
 ``var`` argument in a ``procedure``.
 
 ``const`` is the default in *Gazprea*: a declaration with no qualifier
-declares a ``const`` variable. This section is the normative home of that
-rule; other chapters reference it. Writing ``const`` explicitly is
-therefore redundant, except where the qualifier entirely replaces the
-type (the inference form below).
+declares a ``const`` variable. Both ``T x`` (qualifier elided) and
+``const T x`` (qualifier written explicitly) are legal spellings of the
+same declaration. Writing ``const`` is therefore redundant, except where
+the qualifier entirely replaces the type (the inference form below).
+This section is the normative home of that rule; other chapters reference
+it.
 
 
 .. _ssec:typeQualifiers_var:


### PR DESCRIPTION
**PR #18 in the spec-review stack.** Two commits.

## What

1.  `refactor(gazprea): single home for const-by-default rule`
    (2957c06). The "variables are const by default" rule appeared in
    three files. `type_qualifiers.rst` is now the normative home; the
    other two sites (`declarations.rst`, `type_inference.rst`)
    cross-reference it. The misleading "essentially a no-op" wording
    is replaced with a clearer statement that acknowledges the
    inference-form exception.

2.  `refactor(gazprea): state the "both spellings legal" sub-rule and
    close the last duplicate` (3b04562). Human-review polish:
    - The normative paragraph in `type_qualifiers.rst` now names the
      default-is-const rule explicitly, but the "both spellings are
      legal" corollary was only *implicit* ("writing `const` is
      therefore redundant"). Add a one-sentence explicit statement
      that `T x` and `const T x` are exchangeable — the normative
      section shouldn't rely on inference.
    - `procedures.rst:9` was the last remaining restatement ("By
      default arguments are `const` just like functions"). Its scope
      (parameter-passing) is narrower than the variable-declaration
      rule and worth keeping in place for readers landing on the
      procedures chapter, but it should point at the normative home
      so it does not become a fourth divergent copy. Add
      `(see :ref:\`sec:typeQualifiers\`)`.

## Verified

- **Information conservation** — CONFIRMED. New paragraph covers
  (a) declaration with no qualifier declares const, (b) `var` opts
  in (still stated in the adjacent Var subsection), (c) both
  spellings legal (now explicit).
- **Globals-vs-locals distinction survives.** `globals.rst`'s
  mandatory-const rule was not touched or misdirected.
- **Cross-refs resolve.** `sec:typeQualifiers` label is at
  `type_qualifiers.rst:1`.

## Signatures

Both commits signed with the agent's session key (`F38D8669…FAC880`);
public key vendored via PR #110.