### PR TITLE
[stack 11/20] spec(gazprea): specify combined struct-plus-instance declaration

### DIFF
--- a/gazprea/spec/types/struct.rst
+++ b/gazprea/spec/types/struct.rst
@@ -35,6 +35,13 @@ and ``struct_field``.
 The instance variables ``t1`` and ``t2`` have types ``s1`` and ``Another``,
 respectively.
 
+A struct declaration may optionally be followed by an identifier, as in
+the first example: ``struct s1 (...) t1;`` declares the type ``s1`` *and*
+a variable ``t1`` of that type in one statement, exactly equivalent to
+``struct s1 (...); s1 t1;``. The combined form takes no qualifier, so the
+variable it declares is ``const`` (the default); to declare a mutable
+instance, use the split form with ``var``, as the ``t2`` example does.
+
 
 .. _sssec:struct_typealias:
 
@@ -59,9 +66,9 @@ A struct can be typealiased and used in any context a regular struct declaration
 Access
 ~~~~~~
 
-  * ``field`` is a field within struct ``T``
+Struct fields are accessed with dot notation, ``instance.field``, where
+``field`` is a field of the instance's struct type. For example:
 
-For example:
 ::
 
      struct s1 (integer i, real r, integer[10] iv);


### PR DESCRIPTION
Origin: `spec-patches/19-fix-struct-decl-form.patch` (backlog audit).

## What

Two changes to `gazprea/spec/types/struct.rst`:

1. Add a paragraph documenting the `struct S (...) x;` combined form (declaring type + instance in one statement) as sugar for `struct S (...); S x;`, appearing in every existing example but never previously described.
2. Rewrite the orphaned bullet at the top of the `Access` section (residue from a deleted table) as a proper prose intro to dot-notation access.

## Audit — ambiguity for reviewer attention

The patch asserts *"The combined form takes no qualifier, so the variable it declares is `const` (the default)"* and *"to declare a mutable instance, use the split form with `var`."*

That claim is **inferred** from the existing examples (every combined-form example is unqualified; the only mutable instance in the file uses the split form as `var Another t2;`). No pre-existing spec text says qualifiers are illegal in the combined form. If the reference implementation accepts `var struct S (...) x;`, this normative claim is wrong.

Ways to resolve, in decreasing order of certainty:
- Check `gazc`'s grammar / a positive/negative test case
- Ask the language owner whether the combined form ever took a qualifier historically
- Fall back: relax the claim to "the examples in this section use the combined form without qualifiers" and drop the normative sentence entirely.

## Stack

Depends on [#111](https://github.com/cmput415/415-docs/pull/111); part of stack [#121](https://github.com/cmput415/415-docs/stack/121). Titles will renumber to `[stack N/19]` once all backlog PRs are opened.

🤖 Backlog patch applied by [Claude Code](https://claude.com/claude-code)