### PR TITLE
[stack 12/20] spec(gazprea): state the mixed concatenation result type

### DIFF
--- a/gazprea/spec/types/string.rst
+++ b/gazprea/spec/types/string.rst
@@ -11,7 +11,7 @@ but because it is an object *Gazprea* can provide type specific features.
 String vectors behave a lot like character arrays, but there are several
 differences between the two types:
 an :ref:`extra literal style <sssec:string_lit>`,
-the :ref:`result of a concatenation <sssec:string_ops>`
+the :ref:`result type of a concatenation <sssec:string_ops>`
 and :ref:`behaviour when sent to an output stream <sssec:output_format>`.
 
 .. _sssec:string_decl:
@@ -69,7 +69,9 @@ As character vectors, strings have all of the same operations defined on them as
 the other array data types.
 Remember that because a ``string`` and vector of ``character`` are fundamentally
 the same, the concatenation operation may be used to concatenate values of the
-two types. You may also append a slice of characters to a string using the
+two types. The result type follows the operands: if at least one operand of
+``||`` is a ``string``, the result is a ``string``; a concatenation of
+character arrays (or characters) alone yields a character array. You may also append a slice of characters to a string using the
 append method.
 As well, a :term:`scalar <scalar type>` character may be concatenated onto
 a string in the same way as it would be concatenated onto an array of


### PR DESCRIPTION
Origin: `spec-patches/20-fix-string-concat-result.patch` (backlog audit).

## What

`gazprea/spec/types/string.rst`: state the result-type rule the intro promised but the operations section never delivered.

1. Intro cross-ref link text: `result of a concatenation` → `result type of a concatenation` (matches what the target section now describes).
2. Operations section: add one sentence to the ``||`` paragraph — if at least one operand is a `string`, the result is a `string`; a concatenation of character arrays (or characters) alone yields a character array.

## Audit — ambiguities for reviewer attention

- The `string || char_array = string` half is grounded in the existing `letters` example. The `char_array || char_array = char_array` half is not exemplified and is an **inference** from the intro's promise that concatenation result-type is what makes strings differ from character arrays.
- The parenthetical *"(or characters)"* extends the rule to `char || char = char_array`. That is a stronger claim — the spec does not currently define whether `char || char` is legal at all. Confirm with `gazc` or the language owner before this lands as normative.
- If the reference implementation instead promotes char-array to string whenever the *left* operand is string (or vice versa), the phrasing "at least one operand" needs to drop to "either operand".

## Stack

Depends on [#122](https://github.com/cmput415/415-docs/pull/122); part of stack [#121](https://github.com/cmput415/415-docs/stack/121).

🤖 Backlog patch applied by [Claude Code](https://claude.com/claude-code)