### PR TITLE
[stack 13/20] spec(gazprea): tuple member conversions cover array members

### DIFF
--- a/gazprea/spec/type_casting.rst
+++ b/gazprea/spec/type_casting.rst
@@ -117,8 +117,10 @@ Tuple to Tuple
 
 Conversions between ``tuple`` types are also possible. The original type
 and the destination type must have an equal number of internal types and
-each element must be pairwise castable according to the rules
-in :ref:`ssec:typeCasting_stos`. For example:
+each element must be pairwise castable: scalar members follow
+:ref:`ssec:typeCasting_stos`, and array members follow
+:ref:`ssec:typeCasting_vtov` (including padding and truncation). For
+example:
 
 ::
 

--- a/gazprea/spec/type_promotion.rst
+++ b/gazprea/spec/type_promotion.rst
@@ -93,7 +93,9 @@ Tuple to Tuple
 
 Tuples may be promoted to another tuple type if it has an equal number of
 internal types and the original internal types can be implicitly
-converted to the new internal types. For example:
+converted to the new internal types. Each member converts by the rule for
+its own kind: scalar members follow the scalar promotion table above, and
+array members follow the array promotion rules. For example:
 
 ::
 


### PR DESCRIPTION
Origin: `spec-patches/21-fix-tuple-conversion-members.patch` (backlog audit).

## What

`gazprea/spec/type_casting.rst` and `type_promotion.rst`: the *Tuple to Tuple* sections only cited the scalar pairwise rules, but tuples may contain arrays (`boolean[2]` appears in this chapter's own examples). Members now convert by the rule for their kind:

- **type_casting.rst** — scalar members → `:ref:\`ssec:typeCasting_stos\``, array members → `:ref:\`ssec:typeCasting_vtov\`` (verified both labels exist).
- **type_promotion.rst** — scalar members → the scalar promotion table; array members → the array promotion rules. Wording is looser here because no equivalent single labelled section exists for array promotion.

## Audit — ambiguities for reviewer attention

- Both files claim tuple members "convert by the rule for their kind" and enumerate *scalar* + *array*. **Missing kinds not explicitly addressed**: nested `tuple` members (the spec says tuples cannot nest, but if that ever relaxes the rule is silent), `string` members, `matrix` members. If any of those are legal tuple members, the "for its kind" phrasing should list them or be broadened.
- On promotion, the phrase "array promotion rules" is vague — there is no single labelled section to point at. If a future PR moves the array-promotion rules into a labelled subsection, this cross-ref should be tightened to `:ref:`.
- The parenthetical *"(including padding and truncation)"* in the casting patch describes vtov behavior. Confirm that array-in-tuple casts truly pad/truncate the same way standalone array casts do — the rule is asserted here but not tested against the reference implementation.

## Stack

Depends on [#123](https://github.com/cmput415/415-docs/pull/123); part of stack [#121](https://github.com/cmput415/415-docs/stack/121).

🤖 Backlog patch applied by [Claude Code](https://claude.com/claude-code)