### PR TITLE
[stack 14/20] spec(gazprea): close two silent contract gaps (uninit const, stride)

### DIFF
--- a/gazprea/spec/declarations.rst
+++ b/gazprea/spec/declarations.rst
@@ -36,6 +36,9 @@ The default value is ``0`` for ``integer`` and ``real``,
 string ``""`` for ``string``, and the element-wise default for
 :term:`aggregate types <aggregate type>` (arrays, vectors, tuples,
 structs).  *Gazprea* has no ``null`` value.
+This applies to ``const`` declarations as well: a ``const`` variable
+declared without an initializer is legal and holds the default value of
+its type permanently.
 
 For simplicity *Gazprea* assumes that declarations can only appear at
 the beginning of a block. For instance this would not be legal in

--- a/gazprea/spec/types/array.rst
+++ b/gazprea/spec/types/array.rst
@@ -284,9 +284,10 @@ Operations
 
    e. Stride
 
-      The ``by`` operator is used to specify a step-size greater than 1 when
-      indexing across an array. It produces an array with the values
-      indexed by the given stride. For instance:
+      The ``by`` operator is used to specify a positive step size
+      (``>= 1``) when indexing across an array. It produces an array with
+      the values indexed by the given stride. A stride ``<= 0`` raises a
+      ``StrideError`` (see :ref:`sec:errors`). For instance:
 
       ::
 


### PR DESCRIPTION
Origin: `spec-patches/22-fix-uninit-const-and-stride.patch` (backlog audit). Rebased against a rewording of the intro sentence in `declarations.rst` — the substantive addition (the `const` sub-clause) applied on top of the current phrasing.

## What

1. `gazprea/spec/declarations.rst` — the zero-default rule was silent about `const`; a `const` declared without an initializer was legal by composition of rules but never acknowledged. Now stated inline: permanent zero value of the type.
2. `gazprea/spec/types/array.rst` — the `by` (stride) operator claimed "step-size greater than 1" while its own examples used `by 1`, and no error was named for non-positive strides. Now: positive step size (`>= 1`); a stride `<= 0` raises `StrideError` (verified: `StrideError` is listed in `gazprea/impl/errors.rst`).

## Audit — ambiguities for reviewer attention

- **Negative strides**: the patch rules out `<= 0`. If the language ever intends `by -1` for reverse iteration, this closes that door. Confirm this is what you want the spec to say.
- **`StrideError` chapter**: cross-references `:ref:\`sec:errors\`` which lives in `gazprea/impl/errors.rst` (not `gazprea/spec/`). The [#111](https://github.com/cmput415/415-docs/pull/111) pattern this follows uses the same cross-ref, so consistent. If [#111](https://github.com/cmput415/415-docs/pull/111)'s convention changes (e.g. moves an authoritative error list into `gazprea/spec/`), this should follow.
- **`const` zero-default**: the added sentence says "holds the zero value of its type *permanently*." The word "permanently" is doing work — it distinguishes uninit-const (zero forever) from uninit-var (zero only until first assignment). Confirm that framing matches the intended semantics; the alternative reading is that "uninit const" is a *type error*, not a zero-defaulted legal declaration.

## Conflict resolution

Upstream had rephrased the paragraph's second sentence (`"the second declaration style is equivalent to ..."` → `"if the explicit inialization is omitted it is equivalent to ..."`). Kept the new phrasing verbatim and appended the patch's normative `const` clause. Preserved the pre-existing typo *"inialization"* — belongs to a typo-sweep PR, not this one.

## Stack

Depends on [#124](https://github.com/cmput415/415-docs/pull/124); part of stack [#121](https://github.com/cmput415/415-docs/stack/121).

🤖 Backlog patch applied by [Claude Code](https://claude.com/claude-code)