### PR TITLE
[stack 15/20] spec(gazprea): unify slice bound rule in one section

### DIFF
--- a/gazprea/spec/functions.rst
+++ b/gazprea/spec/functions.rst
@@ -196,7 +196,7 @@ Like Rust, array *slices* may be passed as arguments:
 
          function slicer() returns real[*] {
              integer[10] a = 1..10;
-             var vector<real> two_halves = to_real_vec(a[1..5]);
+             var vector<real> two_halves = to_real_vec(a[1..6]);
              two_halves.append(to_real_vec(a[6..]));
              return two_halves;
          }

--- a/gazprea/spec/types/array.rst
+++ b/gazprea/spec/types/array.rst
@@ -299,41 +299,8 @@ Operations
 
    d. Slices
 
-      A slice is a contiguous subset of array elements. The subset is described
-      by a range
-      The left hand index is inclusive, while the right is exclusive.
-
-      ::
-
-         integer[*] a = 0..10 by 2; /* a = [0, 2, 4, 6, 8, 10] */
-         integer[2] x = a[2..4]; /* subset is a[2] and a[3], x == [2, 4] */
-         integer[*] y = a[..4]; /* slice used as an r-value */
-         a[4..] = 0; /* slice being used as an l-value */
-
-      Note that for slicing the range always has a stride of 1.
-      For indexing purposes three additions are made to range syntax:
-
-      +---------+---------------------------------+
-      |         | Interpretation                  |
-      +---------+---------------------------------+
-      + `..`    | all elements                    |
-      +---------+---------------------------------+
-      + `i..`   | ith to nth elements             |
-      +---------+---------------------------------+
-      + `..-i`  | first to n-i-1th elements       |
-      +---------+---------------------------------+
-      + `i..j`  | i to jth elements               |
-      +---------+---------------------------------+
-
-      Examples:
-
-      ::
-
-         integer[*] a = 0..10 by 2; /* a = [0, 2, 4, 6, 8, 10] */
-         integer x = a[..4]; /* x == [0, 2, 4] */
-         integer y = a[4..]; /* y == [6, 8, 10] */
-         integer z = a[..-1]; /* z == [0, 2, 4, 6, 8] */
-
+      A slice is a contiguous subset of array elements. Slice bounds
+      and shorthand forms are specified in :ref:`sssec:array_slices`.
 
 #. Operations of the Element Type
 
@@ -413,6 +380,30 @@ Array Slices
 ~~~~~~~~~~~~
 
 An array slice is a contiguous subset of elements, described by a range.
+The left hand bound is *inclusive* and the right hand bound is
+*exclusive*. (Note that this differs from a range *value*, whose bounds
+are both inclusive: ``0..10`` written as an expression produces the
+integers 0 through 10, while the same syntax written inside an index
+position selects elements with a right-exclusive bound.) Slicing always
+has a stride of 1; apply ``by`` to the slice result for larger strides.
+
+The following forms are accepted inside an index position, where ``n`` is
+the length of the array being sliced and elements are 1-indexed:
+
++-----------+-----------------------------------------+
+| Form      | Elements selected                       |
++===========+=========================================+
+| ``..``    | all elements, ``1`` through ``n``       |
++-----------+-----------------------------------------+
+| ``i..``   | ``i`` through ``n``                     |
++-----------+-----------------------------------------+
+| ``..j``   | ``1`` through ``j-1``                   |
++-----------+-----------------------------------------+
+| ``..-i``  | ``1`` through ``n-i``                   |
++-----------+-----------------------------------------+
+| ``i..j``  | ``i`` through ``j-1``                   |
++-----------+-----------------------------------------+
+
 An array slice behaves semantically as a new array containing
 the array elements captured by the slice, as shown below.
 
@@ -422,6 +413,10 @@ the array elements captured by the slice, as shown below.
     integer[*] a = 0..10 by 2; /* a = [0, 2, 4, 6, 8, 10] */
     integer[2] x = a[2..4]; /* x == [2, 4] */
     integer y = a[2..4][1]; /* y == 2 */
+
+    integer[*] u = a[..4];  /* u == [0, 2, 4] */
+    integer[*] v = a[4..];  /* v == [6, 8, 10] */
+    integer[*] w = a[..-1]; /* w == [0, 2, 4, 6, 8] */
 
     // A slice of the entire array behaves as the array itself, this can be repeated
     integer z1 = a[4];                   /* z1 == 6 */


### PR DESCRIPTION
Origin: `spec-patches/04-fix-slice-bounds.patch` (backlog audit). Rebased onto substantial rewording of the same sections by [#114](https://github.com/cmput415/415-docs/pull/114); resolved by combining #114's cleaner intro sentences with this patch's authoritative table.

## What

Consolidates the slice-bounds rule to a single authoritative home under `sssec:array_slices`.

1. `gazprea/spec/types/array.rst`
   - **Operations item d (Slices)**: reduced to a one-liner that defers to the authoritative section — no more duplicate normative content.
   - **Array Slices section**: repaired grid table (previously failed to parse), corrected the off-by-one bugs in the `..-i` and `i..j` rows, added a note distinguishing range-*value* semantics (inclusive) from range-*in-index-position* semantics (right-exclusive), and added three worked examples (`a[..4]`, `a[4..]`, `a[..-1]`) alongside the existing ones.
2. `gazprea/spec/functions.rst` — `two_halves` example: `a[1..5]` → `a[1..6]` so the two halves are truly halves (right-exclusive bound; previously off by one).

## Audit — ambiguities for reviewer attention

- **`..-i` semantics** — the corrected table says `..-i` selects `1` through `n-i`. Original wording claimed `n-i-1th`; both fell out of the same right-exclusive bound applied to `n-i+1`. Confirm this is what `gazc` accepts.
- **1-indexed assertion** — the table's caption states elements are 1-indexed. If the spec elsewhere is ambivalent about 0- vs 1-indexing, that assertion is doing work; make sure it doesn't contradict another chapter.
- **`by` on slices** — patch says "apply `by` to the slice result for larger strides". Confirm the grammar accepts `a[i..j] by 2` in that form vs `a[i..j by 2]`.

## Conflict resolution

[#114](https://github.com/cmput415/415-docs/pull/114) had rewritten the intro paragraphs of both *Operations d.* and the *Array Slices* section. Kept [#114](https://github.com/cmput415/415-docs/pull/114)'s "A slice is a contiguous subset of array elements" opening in both places, then applied this patch's structural change: item d. becomes a one-liner deferral, and the authoritative section gets the corrected table + inclusive/exclusive prose. Preserved [#114](https://github.com/cmput415/415-docs/pull/114)'s "new array containing" wording verbatim in the section trailer.

## Stack

Depends on [#125](https://github.com/cmput415/415-docs/pull/125); part of stack [#121](https://github.com/cmput415/415-docs/stack/121).

🤖 Backlog patch applied by [Claude Code](https://claude.com/claude-code)