### PR TITLE
[stack 18/20] spec(gazprea): specify the method-call surface

### DIFF
--- a/gazprea/spec/types/string.rst
+++ b/gazprea/spec/types/string.rst
@@ -76,13 +76,14 @@ append method.
 As well, a :term:`scalar <scalar type>` character may be concatenated onto
 a string in the same way as it would be concatenated onto an array of
 characters.
-Note that because a ``string`` is a sub-type of ``vector``, concatenation may also
-be accomplished with ``concat`` and ``push`` methods:
+Note that because a ``string`` is a sub-type of ``vector``, concatenation may
+also be accomplished with the ``append`` and ``push`` methods (see
+:ref:`sssec:vec_methods`; strings have exactly the vector method set):
 
 ::
 
   var string letters = ['a', 'b'] || "cd";
-  letters.concat("ef");
+  letters.append("ef");
   letters.push('g');
   letters  -> std_output;
 

--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -74,13 +74,41 @@ In particular, operand lengths must match for binary expressions and dot
 product. All binary operations between a vector and an array produce
 array results.
 
-As a language supported object, *Gazprea* provides several methods for ``vector``:
+.. _sssec:vec_methods:
+
+Method Calls
+~~~~~~~~~~~~
+
+As a language supported object, *Gazprea* provides methods for ``vector``
+(and its sub-type :ref:`string <ssec:string>`). A method call has the form
+``receiver.method(arguments)`` and is governed by the following rules:
+
+- The receiver must be a variable of a language-supported object type
+  (``vector`` or ``string``). Arrays, array slices, and the (array-valued)
+  results of expressions have no methods; calling a method on them is a
+  compile-time ``TypeError``.
+
+- A method call whose result is used is an expression. A method call may
+  also stand alone as a statement, terminated by a semicolon; this is the
+  only expression form that may be used as a statement.
+
+- Mutating methods (``push``, ``append``) additionally require the
+  receiver to be declared ``var``. Inside a :ref:`function <sec:function>`,
+  mutating methods may be applied only to variables local to the function;
+  this preserves function purity, since no state outside the function can
+  change.
+
+The methods are:
 
 - ``push(T)`` - pushes a new element to the back of the vector, where ``T`` is the element type of the vector
 
 - ``len()`` - number of elements in the vector
 
-- ``append(T[*])`` - append another array to the vector where ``T[*]`` is the type of the original vector or a type that can be implicitly cast to it.
+- ``append(x)`` - append to the vector, where ``T`` is the element type:
+  if ``x`` is promotable to ``T`` it is appended as a single element;
+  otherwise ``x`` must be an array whose elements are each promotable to
+  ``T``, and its elements are appended in order. When both readings apply,
+  the single-element reading is used.
 
    ::
 
@@ -110,9 +138,10 @@ As a language supported object, *Gazprea* provides several methods for ``vector`
 
         v2.len() -> std_output         // 3
 
-        v2.len();                      // Does nothing
+        v2.len();                      // Legal statement; result discarded
 
-        (v1 + v2).push(3);             // Effectively does nothing, reference to the sum is dropped after the statement
+        (v1 + v1).push(3);             // TypeError: the sum is an array
+                                       // value, and arrays have no methods
 
 Slicing a vector produces an array slice (there are no "vector slices").
 


### PR DESCRIPTION
Origin: `spec-patches/08-feat-method-calls.patch` (backlog audit). Substantive normative addition — flagged for close review.

## What

Method calls appeared throughout `types/vector.rst` and `types/string.rst` with no grammar, receiver rules, or purity story; `string.rst` invoked a `concat` method defined nowhere; and `append`'s signature contradicted its own examples.

- **`types/vector.rst`** — new *Method Calls* subsection (label `sssec:vec_methods`) covering:
  - Receiver must be a `vector` or `string` variable; arrays/slices/expression results have no methods (compile-time `TypeError`).
  - Method call as statement (unique among expression forms).
  - Purity story for mutating methods (`push`, `append`): `var` receiver, function-local when inside a function.
  - `append(x)` disambiguated: single-element if promotable, otherwise element-wise; single-element wins ties.
  - Replaced ill-typed `(v1 + v2).push(3)` example (`vector<integer> + vector<real[2]>`) with `(v1 + v1).push(3)` illustrating the array-slice `TypeError` rule.
- **`types/string.rst`** — cross-links to the new `sssec:vec_methods` and states strings have exactly the vector method set. Renamed `letters.concat("ef")` → `letters.append("ef")`.

## Audit — ambiguities for reviewer attention

This is the largest patch of the backlog and the only `feat:` — it adds normative surface, not a fix. High-value ambiguities:

- **Receiver types**: patch says receivers may be *variables* only ("no methods on array-valued expression results"). Confirm whether the reference implementation accepts `x.len()` where `x` is a literal or a function result; if so, the receiver rule should widen to "any expression whose type is `vector`/`string`" and the `(v1+v1).push(3)` example needs a different justification.
- **Function-local mutation**: the purity rule limits mutating methods inside a function to *function-local* variables. That is stricter than "no mutation of captured/global state". Confirm which framing matches the language semantics — the patch chose the local-only one because it is easier to enforce syntactically.
- **`append` single-vs-element-wise tie-break**: patch declares the single-element reading wins on ambiguity. This is a language design decision — reviewer should confirm this matches the reference implementation. The alternative tie-break (prefer element-wise, or reject ambiguous calls as `TypeError`) has different ergonomics.
- **Method as statement**: "the only expression form that may be used as a statement" — cross-check against `expressions.rst` and `statements.rst`. If procedure calls also stand alone (they do, in `call` statements), the "only" needs qualifying.
- **`concat` → `append` rename**: this is a breaking change for any existing test programs invoking `concat`. If existing tests or the reference implementation still expose `concat` as an alias, that alias needs mentioning in the spec.

## Stack

Depends on [#128](https://github.com/cmput415/415-docs/pull/128); part of stack [#121](https://github.com/cmput415/415-docs/stack/121).

🤖 Backlog patch applied by [Claude Code](https://claude.com/claude-code)