### PR TITLE
[stack 19/20] spec(gazprea): correct misleading examples (batched)

### DIFF
--- a/gazprea/spec/namespaces.rst
+++ b/gazprea/spec/namespaces.rst
@@ -6,7 +6,8 @@ Namespaces
 There are two namespaces in *Gazprea*:
 
 - Type namespace: user-defined types (structs and typealiases).
-- Variable/Function/procedure namespace: functions and procedures.
+- Variable/Function/procedure namespace: variables, functions, and
+  procedures.
 
 Items in separate namespaces may share an :term:`identifier`. Items within the same namespace cannot share an identifier, this is a ``SymbolError``.
 

--- a/gazprea/spec/statements.rst
+++ b/gazprea/spec/statements.rst
@@ -36,7 +36,7 @@ promoted to the type of the variable. For instance:
          var real real_var = 0.0;
          var boolean bool_var = true;
 
-         /* Since 'x' is an integer it can be promoted to a real number \*/
+         /* Since 'int_var' is an integer it can be promoted to a real number */
          real_var = int_var;  /* Legal */
 
          /* Real numbers can not be turned into boolean values automatically. \*/
@@ -225,7 +225,7 @@ is actually equivalent to the following:
 
 ::
 
-         if (x == 4) {
+         if (x == 3) {
            y = 7;
          }
 

--- a/gazprea/spec/type_qualifiers.rst
+++ b/gazprea/spec/type_qualifiers.rst
@@ -61,7 +61,7 @@ type must be inferred. A variable declared in this manner must be
 ::
 
      var i = 1; // integer
-     const i = 1; // integer
+     const j = 1; // integer
      var r = 1.0; // real
      const c = 'a'; // character
      var t = (1, 2, 'a', [1, 2, 3]); // tuple(integer, integer, character, integer[3])

--- a/gazprea/spec/types/tuple.rst
+++ b/gazprea/spec/types/tuple.rst
@@ -67,7 +67,7 @@ parentheses in a comma separated list. For example:
 ::
 
      tuple(integer, character[5], integer[3])  my_tuple = (x, "hello", [1, 2, 3]);
-     var my_tuple = (x, "hello", [1, 2, 3]);
+     var our_tuple = (x, "hello", [1, 2, 3]);
      const your_tuple = (x, "hello", [1, 2, 3]);
      tuple(integer, real, integer[10]) tuple_var = (1, 2.1, [i in 1..10 | i]);
 

--- a/gazprea/spec/types/vector.rst
+++ b/gazprea/spec/types/vector.rst
@@ -46,8 +46,8 @@ streams are not permitted. Below are some examples of
         const vector<integer[2]> v2 = [4, 5];  // [[4, 5]]
         const vector<integer> v3 = 42;         // [42]
         var vector<integer> v4 = 42;           // [42], mutable
-        vector<integer> v4 = 42;               // [42], implied const
-        const vector<real> v5 = 1;             // [1.0]
+        vector<integer> v5 = 42;               // [42], implied const
+        const vector<real> v6 = 1;             // [1.0]
 
 
 Vectors of inferred sized arrays assume the size of the *first* array in the vector.


### PR DESCRIPTION
Origin: `spec-patches/14-fix-example-corrections.patch` (backlog audit). Small batched fixes across five files; each is a self-contained correction.

## What

Five small, unrelated example bugs, one per file:

1. `namespaces.rst` — bulleted enumeration of the Variable/Function/procedure namespace omitted variables even though the example below depended on them.
2. `statements.rst` — the dangling-if desugaring changed its own condition (`x == 4` in the desugared form for `x == 3` in the source; corrected to `x == 3`). Also fixed a comment that referenced a variable named `x` when the example uses `int_var`.
3. `type_qualifiers.rst` — same identifier `i` was declared twice in the type-inference example (`var i = 1; const i = 1;`), which is a `SymbolError` per `namespaces.rst`. Renamed the second to `j`.
4. `types/tuple.rst` — `my_tuple` declared twice in the same scope (`tuple(...) my_tuple = ...; var my_tuple = ...`). Renamed the second to `our_tuple`.
5. `types/vector.rst` — two same-scope redeclarations (`v4` and `v5`). Renamed to `v5` and `v6`.

## Audit

- Each fix is a straightforward correction under existing rules; no new normative content.
- Batched to keep churn low; each hunk stands alone if you want it split into separate PRs.

## Stack

Depends on [#129](https://github.com/cmput415/415-docs/pull/129); part of stack [#121](https://github.com/cmput415/415-docs/stack/121). Top of the stack.

🤖 Backlog patch applied by [Claude Code](https://claude.com/claude-code)