### PR TITLE
fix(theme): point the page source link at GitHub

### DIFF
--- a/gazprea/conf.py
+++ b/gazprea/conf.py
@@ -86,6 +86,19 @@ html_theme_options = {
     'sticky_navigation': False,
 }
 
+# Point the per-page source link at the file on GitHub rather than a local
+# ``_sources/<page>.rst.txt`` copy: the deploy step strips ``_sources/``, so
+# the default link 404s on the published site.  With these set, sphinx_rtd_theme
+# renders a GitHub link built from
+# ``<github_version><conf_py_path><pagename><suffix>``.
+html_context = {
+    'display_github': True,
+    'github_user': 'cmput415',
+    'github_repo': '415-docs',
+    'github_version': 'master',
+    'conf_py_path': '/gazprea/',
+}
+
 html_logo = 'assets/images/logo-reverse.png'
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/generator/conf.py
+++ b/generator/conf.py
@@ -73,6 +73,16 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'sphinx_rtd_theme'
 
+# Point the per-page source link at the file on GitHub rather than a local
+# ``_sources/<page>.rst.txt`` copy (the deploy step strips ``_sources/``).
+html_context = {
+    'display_github': True,
+    'github_user': 'cmput415',
+    'github_repo': '415-docs',
+    'github_version': 'master',
+    'conf_py_path': '/generator/',
+}
+
 html_theme_options = {
     'logo_only': False,
     'style_nav_header_background': '#007C41',

--- a/info/conf.py
+++ b/info/conf.py
@@ -73,6 +73,16 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'sphinx_rtd_theme'
 
+# Point the per-page source link at the file on GitHub rather than a local
+# ``_sources/<page>.rst.txt`` copy (the deploy step strips ``_sources/``).
+html_context = {
+    'display_github': True,
+    'github_user': 'cmput415',
+    'github_repo': '415-docs',
+    'github_version': 'master',
+    'conf_py_path': '/info/',
+}
+
 html_theme_options = {
     'logo_only': False,
     'style_nav_header_background': '#007C41',

--- a/lolcode/conf.py
+++ b/lolcode/conf.py
@@ -72,6 +72,16 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'sphinx_rtd_theme'
 
+# Point the per-page source link at the file on GitHub rather than a local
+# ``_sources/<page>.rst.txt`` copy (the deploy step strips ``_sources/``).
+html_context = {
+    'display_github': True,
+    'github_user': 'cmput415',
+    'github_repo': '415-docs',
+    'github_version': 'master',
+    'conf_py_path': '/lolcode/',
+}
+
 html_theme_options = {
     'logo_only': False,
     'style_nav_header_background': '#007C41',

--- a/setup/conf.py
+++ b/setup/conf.py
@@ -73,6 +73,16 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'sphinx_rtd_theme'
 
+# Point the per-page source link at the file on GitHub rather than a local
+# ``_sources/<page>.rst.txt`` copy (the deploy step strips ``_sources/``).
+html_context = {
+    'display_github': True,
+    'github_user': 'cmput415',
+    'github_repo': '415-docs',
+    'github_version': 'master',
+    'conf_py_path': '/setup/',
+}
+
 html_theme_options = {
     'logo_only': False,
     'style_nav_header_background': '#007C41',

--- a/vcalc/conf.py
+++ b/vcalc/conf.py
@@ -73,6 +73,16 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'sphinx_rtd_theme'
 
+# Point the per-page source link at the file on GitHub rather than a local
+# ``_sources/<page>.rst.txt`` copy (the deploy step strips ``_sources/``).
+html_context = {
+    'display_github': True,
+    'github_user': 'cmput415',
+    'github_repo': '415-docs',
+    'github_version': 'master',
+    'conf_py_path': '/vcalc/',
+}
+
 html_theme_options = {
     'logo_only': False,
     'style_nav_header_background': '#007C41',


### PR DESCRIPTION
## Summary

Every Sphinx page's "View page source" link targeted a local
`_sources/<page>.rst.txt` copy, but the deploy step (root `Makefile`) strips
`_sources/` from each project before publishing — so the link **404'd on the
live site** (it only worked in a local `make html` build).

This sets `sphinx_rtd_theme`'s GitHub context in each deployed project's
`conf.py`, so the link resolves to the source file on GitHub
(`https://github.com/cmput415/415-docs/blob/master/<project>/<page>.rst`,
rendered as "Edit on GitHub") — independent of `_sources/`, so the Makefile's
strip step stays and the published site remains lean.

Applied to all six deployed projects (`setup`, `generator`, `lolcode`,
`vcalc`, `gazprea`, `info`); `conf_py_path` is the only per-project
difference.

Split out of #108 (now merged) since it's unrelated to the glossary.

## Test plan

- [x] Built each project; the source link renders as
  `.../415-docs/blob/master/<project>/<page>.rst`.
- [x] Verified each linked path exists on `master` (`git ls-tree`).
- [x] Confirmed the old `_sources/…` link (which 404s on the deployed site) is
  gone from the built pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
