### PR TITLE
Document the Gazprea project management process and its marks

### DIFF
--- a/gazprea/impl/process.rst
+++ b/gazprea/impl/process.rst
@@ -1,0 +1,47 @@
+.. _sec:gazprea_process:
+
+Project Management
+==================
+
+Gazprea is written by four people in one repository. This page describes how to run that on GitHub.
+
+Best practices
+--------------
+
+Deliver every change through a pull request:
+
+#. Branch from the default branch.
+#. Commit your work to the branch and push it.
+#. Open a pull request against the default branch.
+#. A teammate who did not write it reviews and approves it.
+#. Merge, and delete the branch.
+
+Keep a pull request small enough that a teammate can read it in one sitting.
+
+Track the work in issues:
+
+* Open an issue for each piece of work you have identified. Specification sections you have not implemented yet and test packages that are failing both divide cleanly into issues.
+* **Assign every issue to the member doing it**, and reassign it if the work changes hands.
+* Close issues as the work lands.
+
+If your repository has no **Issues** tab, contact a TA. The tracker is disabled by default and only the teaching team can turn it on.
+
+Marks
+-----
+
+Project management is marked at Part 1 and again at Part 2. The lines and what each is worth are under :external+info:ref:`Gazprea project management marks <sec:gazprea_pm_marks>`.
+
+Enforcing them
+--------------
+
+You can enforce some of these rules with repository rulesets. Consider configuring them for your team's repo.
+
+`Creating rulesets for a repository <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository>`_ covers creating one under Settings → Rules → Rulesets, and `Available rules for rulesets <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets>`_ describes the rules you can choose from.
+
+Creating or editing a ruleset requires repository **admin**. If you do not have admin permissions on your repo, contact a TA.
+
+.. warning::
+   A ruleset applies to everyone it does not explicitly exempt, so it is possible to lock your own team out of your own default branch. Undoing that requires an organisation owner, so contact a TA rather than trying to recover it yourselves.
+
+.. note::
+   © 2024-2026 University of Alberta. All rights reserved.

--- a/gazprea/index.rst
+++ b/gazprea/index.rst
@@ -45,5 +45,6 @@ Hardware Acceleration Laboratory in Markham, ON.
    impl/part_1
    impl/part_2
    impl/errors
+   impl/process
 
 .. |gazprea_logo| image:: assets/images/GazpreaLogo.png

--- a/info/grading.rst
+++ b/info/grading.rst
@@ -46,17 +46,34 @@ It can help to break large tasks into smaller sub-tasks, because sizing can be
 more accurate, but dependencies between sub-tasks must be identified so that a
 critical path can be identified.
 
-The tasks should be recorded and tracked in Github Project.
-The development coding processes, such as commit conventions and reviews,
-should also be agreed upon, and then enforced in the CI pipeline.
-The CI processes should also include building a test suite that can be used for
-regression testing. A typical process is that each feature PR includes tests
-that demonstrate it's correctness.
+Record the tasks you identify as issues, and assign each one to the member doing it. Agree on the rest of the development process early: commit conventions, how a change reaches the default branch, and who reviews it before it does. A typical process is that each feature pull request carries the tests that demonstrate its correctness.
 
 It is important to actually track the tasks that you identified. Often you will
 have to refine/resize them or discover new tasks that must be sized and
 assigned. Only by tracking these tasks can you know that your team can deliver
 your product on time.
+
+.. _sec:gazprea_pm_marks:
+
+Gazprea project management marks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Four marks at Part 1 and four at Part 2, awarded to the team. Setting up the process these are read from is described under :external+gazprea:doc:`Project Management <impl/process>`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 88
+
+   * - Marks
+     - Line
+   * - 1
+     - **Delivery by pull request.** At least four pull requests merged into the default branch during the part.
+   * - 2
+     - **Review before merge.** The fraction of those merged pull requests that a non-author teammate approved before they were merged.
+   * - 1
+     - **Work tracked in issues.** At least two issues opened during the part and assigned to a member.
+
+Counts are taken over the part being marked, so Part 2 starts from zero rather than carrying Part 1 forward.
 
 
 Grammar


### PR DESCRIPTION
**In scope**
- Setting up a default-branch ruleset requiring a reviewed pull request
- Four marks at Part 1 and four at Part 2: PR delivery, review coverage, assigned issues

**Out of scope**
- CI: no required status checks, and no mark for a green default branch
- The Grading Matrix, which already carries Software Engineering at 5%